### PR TITLE
Cli results and Output file

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -93,11 +93,16 @@ Check only files ending in .rb under the 'test' directory:
 Check defaults (lib/**/*.rb):
 
   $ tailor
-  
+
+Printing the results in a output file (if using a formatter that accepts output files, like 'yaml'):
+
+  $ tailor path/to/check --output-file=my-results.yaml
+  $ tailor --output-file=my-results-from-defaults.yaml
+
 Use defaults via a Rake task (if you have a .tailor file, it'll use those settings):
 
   require 'tailor/rake_task'
-  
+
   Tailor::RakeTask.new
 
 ==== On style...
@@ -270,6 +275,21 @@ level to +:off+:
   end
 
 
+===== Formatters
+
+By default Tailor uses the text formatter, printing the results on console. Tailor
+also provides a 'yaml' formatter, that accepts an output file if using the option
+--output-file=*.yaml
+
+  #.tailor
+  Tailor.config do |config|
+    config.formatters 'text', 'yaml'
+
+    # just ones
+    config.formatters 'text'
+  end
+
+
 === Define A Custom Ruler
 
 While tailor provides a number of Rulers for checking style, it also provides a
@@ -342,6 +362,25 @@ add infomation about your ruler to your config file.  If you created a Ruler:
   end
 
 Next time you run tailor, your Ruler will get initialized and used.
+
+=== Using the lib
+
+Sometimes you could use tailor as a lib, getting the results as a hash
+and manipulate them according your domain.
+
+  require 'tailor/cli'
+
+  # only results from a specific path
+  tailor = Tailor::CLI.new %w(app/controllers)
+  tailor.result # result should be a hash {"filename" => [problems]}
+
+  # using other file config (hiding path, it'll use from default config)
+  Tailor::CLI.new %w(--config-file=.other-config)
+  Tailor::CLI.new [] # uses file set from .tailor file config
+
+  # printing the results in a output file
+  tailor = Tailor::CLI.new %w(--output-file=results.yaml)
+  tailor.execute!
 
 == REQUIREMENTS:
 

--- a/lib/tailor/cli.rb
+++ b/lib/tailor/cli.rb
@@ -43,9 +43,13 @@ class Tailor
         @reporter.file_report(problems_for_file, label)
       end
 
-      @reporter.summary_report(@critic.problems)
-
+      @reporter.summary_report(@critic.problems, output_file: @configuration.output_file)
       @critic.problem_count(:error) > 0
+    end
+
+    def result
+      @critic.critique(@configuration.file_sets)
+      @critic.problems
     end
   end
 end

--- a/lib/tailor/cli/options.rb
+++ b/lib/tailor/cli/options.rb
@@ -14,6 +14,7 @@ class Tailor
       def self.parse!(args)
         options = OpenStruct.new
         options.config_file = ''
+        options.output_file = ''
         options.formatters = []
         options.show_config = false
         options.style = {}
@@ -31,6 +32,11 @@ class Tailor
           opt.on('-c', '--config-file FILE',
             "Use a specific config file.") do |config|
             options.config_file = config
+          end
+
+          opt.on('-o', '--output-file FILE',
+            "Print result in a output file if using the proper formatter.") do |output|
+            options.output_file = output
           end
 
           opt.on('--create-config', 'Create a new .tailor file') do

--- a/lib/tailor/configuration.rb
+++ b/lib/tailor/configuration.rb
@@ -30,6 +30,7 @@ class Tailor
 
     attr_reader :file_sets
     attr_reader :formatters
+    attr_reader :output_file
 
     # @param [Array] runtime_file_list
     # @param [OpenStruct] options
@@ -39,6 +40,7 @@ class Tailor
     def initialize(runtime_file_list=nil, options=nil)
       @formatters = ['text']
       @file_sets = {}
+      @output_file = ""
       @runtime_file_list = runtime_file_list
       log "Got runtime file list: #{@runtime_file_list}"
 
@@ -65,6 +67,7 @@ class Tailor
         @file_sets = { default: FileSet.new(@runtime_file_list) }
       end
 
+      get_output_file_from_cli_opts
       get_formatters_from_cli_opts
       get_file_sets_from_cli_opts
       get_style_from_cli_opts
@@ -162,6 +165,13 @@ class Tailor
       end
     end
 
+    def get_output_file_from_cli_opts
+      unless @options.nil? || @options.output_file.nil?
+        @output_file = @options.output_file
+        log "@output_file is now #{@output_file}"
+      end
+    end
+
     def get_formatters_from_cli_opts
       unless @options.nil? || @options.formatters.empty? || @options.formatters.nil?
         @formatters = @options.formatters
@@ -207,6 +217,7 @@ class Tailor
       table.head = [{ value: 'Configuration', colspan: 2, align: :center }]
       table.rows << :separator
       table.rows << ['Formatters', @formatters]
+      table.rows << ['Output File', @output_file]
 
       @file_sets.each do |label, file_set|
         table.rows << :separator

--- a/lib/tailor/formatters/yaml.rb
+++ b/lib/tailor/formatters/yaml.rb
@@ -1,0 +1,43 @@
+require 'pathname'
+require 'yaml'
+require_relative '../formatter'
+
+class Tailor
+  module Formatters
+    class Yaml < Tailor::Formatter
+      attr_reader :accepts_output_file
+
+      def initialize
+        @accepts_output_file = true
+        super
+      end
+
+      # Prints the report on all of the files that just got checked.
+      #
+      # @param [Hash] problems Values are filenames; keys are problems for each
+      #   of those files.
+      def summary_report(problems)
+        build_hash(problems).to_yaml
+      end
+
+      private
+      def build_hash(problems)
+        detected = problems.select {|k,v| !v.empty?}
+        return {} if detected.empty?
+
+        detected.inject({}) do |result, hash|
+          filename = hash[0]
+          probs = hash[1].first
+          result[filename] = {
+            type: probs[:type],
+            line: probs[:line],
+            column: probs[:column],
+            message: probs[:message],
+            level: probs[:level]
+          }
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/tailor/reporter.rb
+++ b/lib/tailor/reporter.rb
@@ -38,10 +38,15 @@ class Tailor
     # Sends the data to each +@formatters+ to generate the reports of problems
     # for all files that were just critiqued.
     #
-    # @param [Hash] all_problems 
-    def summary_report(all_problems)
+    # @param [Hash] all_problems
+    def summary_report(all_problems, opts={})
       @formatters.each do |formatter|
-        formatter.summary_report(all_problems)
+        summary = formatter.summary_report(all_problems)
+        if formatter.respond_to?(:accepts_output_file) &&
+                         formatter.accepts_output_file &&
+                         !opts[:output_file].empty?
+          File.open(opts[:output_file], "w") { |f| f.puts summary }
+        end
       end
     end
   end

--- a/spec/functional/configuration_spec.rb
+++ b/spec/functional/configuration_spec.rb
@@ -240,5 +240,42 @@ end
         config.file_sets[:default].file_list.first.match /lib\/tailor\.rb$/
       end
     end
+
+    context '.tailor defines a yaml formatter' do
+      let(:config_file) do
+        <<-CONFIG
+Tailor.config do |config|
+  config.formatters 'yaml'
+end
+        CONFIG
+      end
+
+      before do
+        File.should_receive(:read).and_return config_file
+      end
+
+      it "sets formatters to 'yaml'" do
+        config.formatters.should == %w(yaml)
+      end
+    end
+
+    context '.tailor defines a more than one formatter' do
+      let(:config_file) do
+        <<-CONFIG
+Tailor.config do |config|
+  config.formatters 'yaml', 'text'
+end
+        CONFIG
+      end
+
+      before do
+        File.should_receive(:read).and_return config_file
+      end
+
+      it "sets formatters to the defined" do
+        config.formatters.should == %w(yaml text)
+      end
+
+    end
   end
 end

--- a/spec/unit/tailor/cli_spec.rb
+++ b/spec/unit/tailor/cli_spec.rb
@@ -81,6 +81,7 @@ describe Tailor::CLI do
     it "calls @critic.critique and yields file problems and the label" do
       problems_for_file = {}
       label = :test
+      config.should_receive(:output_file)
       critic.stub(:problem_count).and_return 1
       critic.stub(:problems)
       critic.stub(:critique).and_yield(problems_for_file, label)
@@ -88,6 +89,27 @@ describe Tailor::CLI do
       reporter.should_receive(:file_report).with(problems_for_file, label)
 
       subject.execute!
+    end
+  end
+
+  describe "#result" do
+    let(:critic) { double "Tailor::Critic", problem_count: 0 }
+
+    before do
+      Tailor::Critic.stub(:new).and_return(critic)
+      subject.instance_variable_set(:@critic, critic)
+    end
+
+    after do
+      Tailor::Critic.unstub(:new)
+    end
+
+    it "calls @critic.critique and return @critique.problems hash" do
+      problems = {}
+      critic.should_receive(:critique)
+      critic.should_receive(:problems).and_return(problems)
+
+      subject.result.should == problems
     end
   end
 end

--- a/spec/unit/tailor/configuration_spec.rb
+++ b/spec/unit/tailor/configuration_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../../spec_helper'
 require 'tailor/configuration'
+require 'tailor/cli'
 
 describe Tailor::Configuration do
   before { Tailor::Logger.stub(:log) }
@@ -103,6 +104,23 @@ describe Tailor::Configuration do
             Tailor::Configuration::DEFAULT_RC_FILE
         end
       end
+    end
+  end
+
+  describe "output file" do
+    context "defined" do
+      subject do
+        parser = Tailor::CLI::Options
+        args = %w(--output-file=tailor-result.yaml)
+        Tailor::Configuration.new(args, parser.parse!(args))
+      end
+
+      before { subject.load! }
+      its(:output_file) { should eq "tailor-result.yaml" }
+    end
+
+    context "not defined" do
+      its(:output_file) { should eq "" }
     end
   end
 end

--- a/spec/unit/tailor/formatters/yaml_spec.rb
+++ b/spec/unit/tailor/formatters/yaml_spec.rb
@@ -1,0 +1,34 @@
+require_relative '../../../spec_helper'
+require 'tailor/formatters/yaml'
+require 'yaml'
+
+describe Tailor::Formatters::Yaml do
+  describe "#summary_report" do
+    let(:problems) do
+      {
+        "/path_to/file1.rb" => [{
+          type: "type1", line: 23, column: 1,
+          message: "Some message", level: :error
+        }],
+        "/path_to/file2.rb" => [{
+          type: "type2", line: 23, column: 1,
+          message: "Some message", level: :error
+        }],
+        "/path_to/file3.rb" => [{
+          type: "type3", line: 23, column: 1,
+          message: "Some message", level: :error
+        }],
+        "path_to/file4.rb" => []
+      }
+    end
+
+    it "should return problems as yaml" do
+      result = subject.summary_report(problems)
+      hash = YAML.load(result)
+      hash.keys.size.should == 3
+      hash.keys.first.should == "/path_to/file1.rb"
+      hash.has_key?('/path_to/file4.rb').should be_false
+      hash['/path_to/file2.rb'][:type].should eq "type2"
+    end
+  end
+end

--- a/spec/unit/tailor/reporter_spec.rb
+++ b/spec/unit/tailor/reporter_spec.rb
@@ -43,11 +43,30 @@ describe Tailor::Reporter do
       t
     end
 
-    it "calls #file_report on each @formatters" do
-      label = :some_label
-      formatter.should_receive(:summary_report).with(all_problems)
+    context "without output file" do
+      it "calls #file_report on each @formatters" do
+        label = :some_label
+        formatter.should_receive(:summary_report).with(all_problems)
+        File.should_not_receive(:open)
 
-      subject.summary_report(all_problems)
+        subject.summary_report(all_problems)
+      end
     end
+
+    context "with output file" do
+      let(:output_file) { "output.whatever" }
+      before do
+        formatter.should_receive(:respond_to?).with(:accepts_output_file).and_return(true)
+        formatter.should_receive(:accepts_output_file).and_return(true)
+      end
+
+      it "calls #summary_report on each @formatters" do
+        formatter.should_receive(:summary_report).with(all_problems)
+        File.should_receive(:open).with(output_file, "w")
+
+        subject.summary_report(all_problems, output_file: output_file)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Hi @turboladen!

First scenario:
I want to be able getting the cli results as a hash. I need to manipulate them for an appropriate application. Then I created a new method on CLI that returns the critc.problems. Just that.

Second scenario:
Sometimes I want to be able printing the report into a yaml file. So I've created a new formatter for that. As a plus we can pass a output-file option on command-line or at config instantiation.

``` ruby
Tailor::CLI.new(
%w(--config-file=.tailor --output-file=my-file.yaml)
lib_to_analyze)

Tailor::CLI.new(
%w(--config-file=.tailor --output-file=my-file42.yaml)
other_lib_to_analyze)
```

This would be great for me, and, I guess, for us!
Can you check, please?

I didn't update the README yet. Let me know if all it's ok.
Thanks for advance!
