### PR TITLE
Line continuations for indentation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     tailor (1.2.1)
       log_switch (>= 0.3.0)
+      nokogiri (>= 1.6.0)
       term-ansicolor (>= 1.0.5)
       text-table (>= 1.2.2)
 
@@ -32,7 +33,10 @@ GEM
     json (1.7.7)
     json (1.7.7-java)
     log_switch (0.4.0)
+    mini_portile (0.5.1)
     multi_json (1.6.1)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
     rake (10.0.3)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)

--- a/lib/tailor/rulers/indentation_spaces_ruler.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler.rb
@@ -1,7 +1,9 @@
+require 'nokogiri'
 require_relative '../ruler'
 require_relative '../lexed_line'
 require_relative '../lexer/token'
 require_relative 'indentation_spaces_ruler/indentation_manager'
+require_relative 'indentation_spaces_ruler/line_continuations'
 
 class Tailor
   module Rulers
@@ -12,6 +14,7 @@ class Tailor
           :comment,
           :embexpr_beg,
           :embexpr_end,
+          :file_beg,
           :ignored_nl,
           :kw,
           :lbrace,
@@ -80,6 +83,13 @@ class Tailor
         end
 
         @manager.update_for_closing_reason(:on_embexpr_end, current_lexed_line)
+      end
+
+      def file_beg_update(file_name)
+        # For statements that continue over multiple lines we may want to treat
+        # the second and subsequent lines differently and ident them further,
+        # controlled by the :line_continuations option.
+        @lines = LineContinuations.new(file_name) if line_continuations?
       end
 
       def ignored_nl_update(current_lexed_line, lineno, column)
@@ -270,6 +280,20 @@ class Tailor
         !@tstring_nesting.empty?
       end
 
+      def line_continuations?
+        @options[:line_continuations] and @options[:line_continuations] != :off
+      end
+
+      def with_line_continuations(lineno, should_be_at)
+        return should_be_at unless line_continuations?
+        if @lines.line_is_continuation?(lineno) and
+          @lines.line_has_nested_statements?(lineno)
+          should_be_at + @config
+        else
+          should_be_at
+        end
+      end
+
       # Checks if the line's indentation level is appropriate.
       #
       # @param [Fixnum] lineno The line the potential problem is on.
@@ -277,9 +301,11 @@ class Tailor
       def measure(lineno, column)
         log "Measuring..."
 
-        if @manager.actual_indentation != @manager.should_be_at
+        should_be_at = with_line_continuations(lineno, @manager.should_be_at)
+
+        if @manager.actual_indentation != should_be_at
           msg = "Line is indented to column #{@manager.actual_indentation}, "
-          msg << "but should be at #{@manager.should_be_at}."
+          msg << "but should be at #{should_be_at}."
 
           @problems << Problem.new(problem_type, lineno,
             @manager.actual_indentation, msg, @options[:level])

--- a/lib/tailor/rulers/indentation_spaces_ruler/ast_xml.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler/ast_xml.rb
@@ -1,0 +1,88 @@
+class Tailor
+  module Rulers
+    class IndentationSpacesRuler < Tailor::Ruler
+
+      # XXX: Reproducing the ast querying functions from foodcritic here. We
+      # either need to re-implement the queries not to rely on these functions
+      # or extract these functions to a shared gem.
+      module AstXml
+
+        def xml_array_node(doc, xml_node, child)
+          n = xml_create_node(doc, child)
+          xml_node.add_child(build_xml(child, doc, n))
+        end
+
+        def xml_create_node(doc, c)
+          Nokogiri::XML::Node.new(c.first.to_s.gsub(/[^a-z_]/, ''), doc)
+        end
+
+        def xml_document(doc, xml_node)
+          if doc.nil?
+            doc = Nokogiri::XML('<opt></opt>')
+            xml_node = doc.root
+          end
+          [doc, xml_node]
+        end
+
+        def xml_hash_node(doc, xml_node, child)
+          child.each do |c|
+            n = xml_create_node(doc, c)
+            c.drop(1).each do |a|
+              xml_node.add_child(build_xml(a, doc, n))
+            end
+          end
+        end
+
+        def xml_position_node(doc, xml_node, child)
+          pos = Nokogiri::XML::Node.new("pos", doc)
+          pos['line'] = child.first.to_s
+          pos['column'] = child[1].to_s
+          xml_node.add_child(pos)
+        end
+
+        def ast_hash_node?(node)
+          node.first.respond_to?(:first) and node.first.first == :assoc_new
+        end
+
+        def ast_node_has_children?(node)
+          node.respond_to?(:first) and ! node.respond_to?(:match)
+        end
+
+        # If the provided node is the line / column information.
+        def position_node?(node)
+          node.respond_to?(:length) and node.length == 2 and
+          node.respond_to?(:all?) and node.all? do |child|
+            child.respond_to?(:to_i)
+          end
+        end
+
+        def build_xml(node, doc = nil, xml_node=nil)
+          doc, xml_node = xml_document(doc, xml_node)
+
+          if node.respond_to?(:each)
+            # First child is the node name
+            node.drop(1).each do |child|
+              if position_node?(child)
+                xml_position_node(doc, xml_node, child)
+              else
+                if ast_node_has_children?(child)
+                  # The AST structure is different for hashes so we have to treat
+                  # them separately.
+                  if ast_hash_node?(child)
+                    xml_hash_node(doc, xml_node, child)
+                  else
+                    xml_array_node(doc, xml_node, child)
+                  end
+                else
+                  xml_node['value'] = child.to_s unless child.nil?
+                end
+              end
+            end
+          end
+          xml_node
+        end
+
+      end
+    end
+  end
+end

--- a/lib/tailor/rulers/indentation_spaces_ruler/line_continuations.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler/line_continuations.rb
@@ -1,0 +1,57 @@
+require 'ripper'
+require_relative './ast_xml'
+
+class Tailor
+  module Rulers
+    class IndentationSpacesRuler < Tailor::Ruler
+
+      # Determines whether a line is a continuation of previous lines. For ease
+      # of implementation we use the s-exp support in Ripper, rather than trying
+      # to work it out solely from the token events on the ruler.
+      class LineContinuations
+
+        include AstXml
+
+        def initialize(file_name)
+          @ast = build_xml(Ripper::SexpBuilder.new(File.read(file_name)).parse)
+        end
+
+        # Is the specified line actually a previous line continuing?
+        def line_is_continuation?(lineno)
+          @continuations ||= begin
+            statements = @ast.xpath('//stmts_add/*[
+              preceding-sibling::stmts_new]')
+            statements.reject do |stmt|
+              s = stmt.xpath('ancestor::stmts_add').size
+              stmt.xpath("descendant::pos[count(ancestor::stmts_add) = #{s}]/
+                @line").map { |s| s.to_s.to_i }.uniq.size < 2
+            end.reject { |stmt| stmt.name == 'case' }.map do |stmt|
+              lines_nesting = lines_with_nesting_level(stmt)
+              lines_nesting.shift
+              min_level = lines_nesting.values.min
+              lines_nesting.reject { |_, n| n > min_level }.keys
+            end.flatten
+          end
+          @continuations.include?(lineno)
+        end
+
+        # Are there statements further nested below this line?
+        def line_has_nested_statements?(lineno)
+          @ast.xpath("//pos[@line='#{lineno}']/
+            ancestor::*[parent::stmts_add][1]/
+            descendant::stmts_add[descendant::pos[@line > #{lineno}]]").any?
+        end
+
+        private
+
+        # Returns a hash of line numbers => nesting level
+        def lines_with_nesting_level(node)
+          Hash[node.xpath('descendant::pos/@line').map do |ln|
+            [ln.to_s.to_i, ln.xpath('count(ancestor::stmts_add)').to_i]
+          end.sort.uniq]
+        end
+
+      end
+    end
+  end
+end

--- a/spec/functional/indentation_spacing/line_continuations_spec.rb
+++ b/spec/functional/indentation_spacing/line_continuations_spec.rb
@@ -1,0 +1,182 @@
+require 'spec_helper'
+require_relative '../../support/line_indentation_cases'
+require 'tailor/critic'
+require 'tailor/configuration/style'
+
+describe 'Line continuation indentation' do
+
+  def file_name
+    self.class.description
+  end
+
+  def contents
+    LINE_INDENT[file_name] || begin
+      raise "Example not found: #{file_name}"
+    end
+  end
+
+  before do
+    Tailor::Logger.stub(:log)
+    FakeFS.activate!
+    FileUtils.touch file_name
+    File.open(file_name, 'w') { |f| f.write contents }
+  end
+
+  let(:critic) { Tailor::Critic.new }
+
+  let(:style) do
+    style = Tailor::Configuration::Style.new
+    style.trailing_newlines 0, level: :off
+    style.allow_invalid_ruby true, level: :off
+    style
+  end
+
+  context :line_continues_further_indented do
+
+    it 'warns when line continuation spacing is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 4,
+        :message=> "Line is indented to column 4, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'warns when line continuation spacing is disabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 4,
+        :message=> "Line is indented to column 4, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'does not warn when line continuation spacing is enabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :line_continues_at_same_indentation do
+
+    it 'does not warn when line continuation spacing is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when line continuation spacing is disabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'warns when line continuation spacing is enabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 2,
+        :message=> "Line is indented to column 2, but should be at 4.",
+        :level=> :error
+      }]
+    end
+
+  end
+
+  context :parameters_continuation_indent_across_lines do
+    it 'warns when line continuation spacing is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 4,
+        :message=> "Line is indented to column 4, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'warns when line continuation spacing is disabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 4,
+        :message=> "Line is indented to column 4, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'warns when line continuation spacing is enabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :parameters_no_continuation_indent_across_lines do
+    it 'warns when line continuation spacing is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'warns when line continuation spacing is disabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'warns when line continuation spacing is enabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 2,
+        :message=> "Line is indented to column 2, but should be at 4.",
+        :level=> :error
+      }]
+    end
+
+  end
+
+  [
+    :hash_spans_lines,
+    :if_else,
+    :line_continues_without_nested_statements,
+    :minitest_test_cases,
+    :nested_blocks,
+    :one_assignment_per_line
+  ].each do |never_warns_example|
+      context never_warns_example do
+
+        it 'does not warn when line continuation spacing is not specified' do
+          critic.check_file(file_name, style.to_hash)
+          expect(critic.problems[file_name]).to be_empty
+        end
+
+        it 'does not warn when line continuation spacing is disabled' do
+          style.indentation_spaces 2, level: :error, line_continuations: :off
+          critic.check_file(file_name, style.to_hash)
+          expect(critic.problems[file_name]).to be_empty
+        end
+
+        it 'does not warn when line continuation spacing is enabled' do
+          style.indentation_spaces 2, level: :error, line_continuations: true
+          critic.check_file(file_name, style.to_hash)
+          expect(critic.problems[file_name]).to be_empty
+        end
+
+      end
+    end
+
+end

--- a/spec/support/line_indentation_cases.rb
+++ b/spec/support/line_indentation_cases.rb
@@ -1,0 +1,71 @@
+LINE_INDENT = {}
+
+LINE_INDENT['hash_spans_lines'] =
+  %q{db_connection = { :host => "localhost", :username => 'root',
+  :password => node['db']['password'] }}
+
+LINE_INDENT['if_else'] =
+  %q{case "foo"
+when "foo"
+  if node["foo"]["version"].to_f >= 5.5
+    default['foo']['service_name'] = "foo"
+    default['foo']['pid_file'] = "/var/run/foo/foo.pid"
+  else
+    default['foo']['service_name'] = "food"
+    default['foo']['pid_file'] = "/var/run/food/food.pid"
+  end
+end}
+
+LINE_INDENT['line_continues_at_same_indentation'] =
+  %q{if someconditional_that == is_really_long.function().stuff() or
+  another_condition == some_thing
+  puts "boop"
+end}
+
+LINE_INDENT['line_continues_further_indented'] =
+  %q{if someconditional_that == is_really_long.function().stuff() or
+    another_condition == some_thing
+  puts "boop"
+end}
+
+LINE_INDENT['line_continues_without_nested_statements'] =
+  %q{attribute "foo/password",
+  :display_name => "Password",
+  :description => "Randomly generated password",
+  :default => "randomly generated"}
+
+LINE_INDENT['minitest_test_cases'] =
+  %q{describe "foo" do
+  it 'includes the disk_free_limit configuration setting' do
+    file("#{node['foo']['config_root']}/foo.config").
+      must_match /\{disk_free_limit, \{mem_relative, #{node['foo']['df']}/
+  end
+  it 'includes the vm_memory_high_watermark configuration setting' do
+    file("#{node['foo']['config_root']}/foo.config").
+      must_match /\{vm_memory_high_watermark, #{node['foo']['vm']}/
+  end
+end}
+
+LINE_INDENT['nested_blocks'] =
+  %q{node['foo']['client']['packages'].each do |foo_pack|
+  package foo_pkg do
+    action :install
+  end
+end}
+
+LINE_INDENT['one_assignment_per_line'] =
+  %q{default['foo']['bar']['apt_key_id'] = 'BD2EFD2A'
+default['foo']['bar']['apt_uri'] = "http://repo.example.com/apt"
+default['foo']['bar']['apt_keyserver'] = "keys.example.net"}
+
+LINE_INDENT['parameters_continuation_indent_across_lines'] =
+  %q{def something(waka, baka, bing,
+    bla, goop, foop)
+  stuff
+end}
+
+LINE_INDENT['parameters_no_continuation_indent_across_lines'] =
+  %q{def something(waka, baka, bing,
+  bla, goop, foop)
+  stuff
+end}

--- a/tailor.gemspec
+++ b/tailor.gemspec
@@ -26,6 +26,7 @@ project, whatever style that may be.
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_runtime_dependency %q<log_switch>, ">= 0.3.0"
+  s.add_runtime_dependency %q<nokogiri>, ">= 1.6.0"
   s.add_runtime_dependency %q<term-ansicolor>, ">= 1.0.5"
   s.add_runtime_dependency %q<text-table>, ">= 1.2.2"
 


### PR DESCRIPTION
Hi Steve,

This is an implementation (really for feedback at this stage) of line-continuation support, related issues are #102 and #92. 

I expect the implementation may be controversial - I've used Ripper's s-expression support rather than trying to determine expression start and end from the lexer tokens. It's also using Nokogiri (as I do elsewhere in foodcritic) to query the AST - that's unconventional and adds a significant new dependency.

Would really appreciate your feedback. 

Thanks,

Andrew.
