### PR TITLE
Align arguments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     tailor (1.2.1)
       log_switch (>= 0.3.0)
+      nokogiri (>= 1.6.0)
       term-ansicolor (>= 1.0.5)
       text-table (>= 1.2.2)
 
@@ -32,7 +33,10 @@ GEM
     json (1.7.7)
     json (1.7.7-java)
     log_switch (0.4.0)
+    mini_portile (0.5.1)
     multi_json (1.6.1)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
     rake (10.0.3)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)

--- a/lib/tailor/rulers/indentation_spaces_ruler.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler.rb
@@ -2,6 +2,7 @@ require 'nokogiri'
 require_relative '../ruler'
 require_relative '../lexed_line'
 require_relative '../lexer/token'
+require_relative 'indentation_spaces_ruler/argument_alignment'
 require_relative 'indentation_spaces_ruler/indentation_manager'
 require_relative 'indentation_spaces_ruler/line_continuations'
 
@@ -90,6 +91,7 @@ class Tailor
         # the second and subsequent lines differently and ident them further,
         # controlled by the :line_continuations option.
         @lines = LineContinuations.new(file_name) if line_continuations?
+        @args = ArgumentAlignment.new(file_name) if argument_alignment?
       end
 
       def ignored_nl_update(current_lexed_line, lineno, column)
@@ -294,6 +296,15 @@ class Tailor
         end
       end
 
+      def argument_alignment?
+        @options[:argument_alignment] and @options[:argument_alignment] != :off
+      end
+
+      def with_argument_alignment(lineno, should_be_at)
+        return should_be_at unless argument_alignment?
+        @args.expected_column(lineno, should_be_at)
+      end
+
       # Checks if the line's indentation level is appropriate.
       #
       # @param [Fixnum] lineno The line the potential problem is on.
@@ -302,6 +313,7 @@ class Tailor
         log "Measuring..."
 
         should_be_at = with_line_continuations(lineno, @manager.should_be_at)
+        should_be_at = with_argument_alignment(lineno, should_be_at)
 
         if @manager.actual_indentation != should_be_at
           msg = "Line is indented to column #{@manager.actual_indentation}, "

--- a/lib/tailor/rulers/indentation_spaces_ruler.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler.rb
@@ -1,7 +1,9 @@
+require 'nokogiri'
 require_relative '../ruler'
 require_relative '../lexed_line'
 require_relative '../lexer/token'
 require_relative 'indentation_spaces_ruler/indentation_manager'
+require_relative 'indentation_spaces_ruler/line_continuations'
 
 class Tailor
   module Rulers
@@ -12,6 +14,7 @@ class Tailor
           :comment,
           :embexpr_beg,
           :embexpr_end,
+          :file_beg,
           :ignored_nl,
           :kw,
           :lbrace,
@@ -80,6 +83,13 @@ class Tailor
         end
 
         @manager.update_for_closing_reason(:on_embexpr_end, current_lexed_line)
+      end
+
+      def file_beg_update(file_name)
+        # For statements that continue over multiple lines we may want to treat
+        # the second and subsequent lines differently and ident them further,
+        # controlled by the :line_continuations option.
+        @lines = LineContinuations.new(file_name) if line_continuations?
       end
 
       def ignored_nl_update(current_lexed_line, lineno, column)
@@ -270,6 +280,20 @@ class Tailor
         !@tstring_nesting.empty?
       end
 
+      def line_continuations?
+        @options[:line_continuations] and @options[:line_continuations] != :off
+      end
+
+      def with_line_continuations(lineno, should_be_at)
+        return should_be_at unless line_continuations?
+        if @lines.line_is_continuation?(lineno) and
+          @lines.line_has_nested_statements?(lineno)
+          should_be_at + @config
+        else
+          should_be_at
+        end
+      end
+
       # Checks if the line's indentation level is appropriate.
       #
       # @param [Fixnum] lineno The line the potential problem is on.
@@ -277,9 +301,11 @@ class Tailor
       def measure(lineno, column)
         log "Measuring..."
 
-        if @manager.actual_indentation != @manager.should_be_at
+        should_be_at = with_line_continuations(lineno, @manager.should_be_at)
+
+        if @manager.actual_indentation != should_be_at
           msg = "Line is indented to column #{@manager.actual_indentation}, "
-          msg << "but should be at #{@manager.should_be_at}."
+          msg << "but should be at #{should_be_at}."
 
           @problems << Problem.new(problem_type, lineno,
             @manager.actual_indentation, msg, @options[:level])

--- a/lib/tailor/rulers/indentation_spaces_ruler/argument_alignment.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler/argument_alignment.rb
@@ -1,0 +1,62 @@
+require 'ripper'
+require_relative './ast_xml'
+
+class Tailor
+  module Rulers
+    class IndentationSpacesRuler < Tailor::Ruler
+
+      # Determines whether arguments spread across lines are correctly
+      # aligned.
+      #
+      # Function calls with parentheses could be determined easily from
+      # the lexed line only but we need to support calls without parentheses
+      # too.
+      class ArgumentAlignment
+
+        include AstXml
+
+        def initialize(file_name)
+          @ast = build_xml(Ripper::SexpBuilder.new(File.read(file_name)).parse)
+          @lex = Ripper.lex(File.read(file_name))
+        end
+
+        def expected_column(lineno, should_be_at)
+          column = call_column(lineno) || declaration_column(lineno)
+          correct_for_literals(lineno, column) || should_be_at
+        end
+
+        private
+
+        # sexp column offsets for string literals do not include the quote
+        def correct_for_literals(lineno, column)
+          tstring_index = @lex.index do |pos, token|
+            pos[0] == lineno and pos[1] == column and
+            token == :on_tstring_content
+          end
+          tstring_index ? @lex[tstring_index -1][0][1] : column
+        end
+
+        def call_column(lineno)
+          [
+            first_argument(:command_call, :args_add_block, lineno),
+            first_argument(:method_add_arg, :args_add_block, lineno)
+          ].compact.min
+        end
+
+        def declaration_column(lineno)
+          first_argument(:def, :params, lineno)
+        end
+
+        def first_argument(parent, child, lineno)
+          method_defs = @ast.xpath("//#{parent}")
+          method_defs.map do |d|
+            d.xpath("descendant::#{child}[descendant::pos[@line = #{lineno}
+              ]]/descendant::pos[position() = 1 and @line != #{lineno}]/
+              @column").first.to_s.to_i
+          end.reject { |c| c == 0 }.min
+        end
+
+      end
+    end
+  end
+end

--- a/lib/tailor/rulers/indentation_spaces_ruler/ast_xml.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler/ast_xml.rb
@@ -57,11 +57,13 @@ class Tailor
         end
 
         def build_xml(node, doc = nil, xml_node=nil)
+          is_params = node.first == :params
           doc, xml_node = xml_document(doc, xml_node)
 
           if node.respond_to?(:each)
             # First child is the node name
-            node.drop(1).each do |child|
+            node.drop(1) if node.first.is_a?(Symbol)
+            node.each do |child|
               if position_node?(child)
                 xml_position_node(doc, xml_node, child)
               else

--- a/lib/tailor/rulers/indentation_spaces_ruler/ast_xml.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler/ast_xml.rb
@@ -57,7 +57,6 @@ class Tailor
         end
 
         def build_xml(node, doc = nil, xml_node=nil)
-          is_params = node.first == :params
           doc, xml_node = xml_document(doc, xml_node)
 
           if node.respond_to?(:each)

--- a/lib/tailor/rulers/indentation_spaces_ruler/ast_xml.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler/ast_xml.rb
@@ -1,0 +1,88 @@
+class Tailor
+  module Rulers
+    class IndentationSpacesRuler < Tailor::Ruler
+
+      # XXX: Reproducing the ast querying functions from foodcritic here. We
+      # either need to re-implement the queries not to rely on these functions
+      # or extract these functions to a shared gem.
+      module AstXml
+
+        def xml_array_node(doc, xml_node, child)
+          n = xml_create_node(doc, child)
+          xml_node.add_child(build_xml(child, doc, n))
+        end
+
+        def xml_create_node(doc, c)
+          Nokogiri::XML::Node.new(c.first.to_s.gsub(/[^a-z_]/, ''), doc)
+        end
+
+        def xml_document(doc, xml_node)
+          if doc.nil?
+            doc = Nokogiri::XML('<opt></opt>')
+            xml_node = doc.root
+          end
+          [doc, xml_node]
+        end
+
+        def xml_hash_node(doc, xml_node, child)
+          child.each do |c|
+            n = xml_create_node(doc, c)
+            c.drop(1).each do |a|
+              xml_node.add_child(build_xml(a, doc, n))
+            end
+          end
+        end
+
+        def xml_position_node(doc, xml_node, child)
+          pos = Nokogiri::XML::Node.new("pos", doc)
+          pos['line'] = child.first.to_s
+          pos['column'] = child[1].to_s
+          xml_node.add_child(pos)
+        end
+
+        def ast_hash_node?(node)
+          node.first.respond_to?(:first) and node.first.first == :assoc_new
+        end
+
+        def ast_node_has_children?(node)
+          node.respond_to?(:first) and ! node.respond_to?(:match)
+        end
+
+        # If the provided node is the line / column information.
+        def position_node?(node)
+          node.respond_to?(:length) and node.length == 2 and
+          node.respond_to?(:all?) and node.all? do |child|
+            child.respond_to?(:to_i)
+          end
+        end
+
+        def build_xml(node, doc = nil, xml_node=nil)
+          doc, xml_node = xml_document(doc, xml_node)
+
+          if node.respond_to?(:each)
+            # First child is the node name
+            node.drop(1).each do |child|
+              if position_node?(child)
+                xml_position_node(doc, xml_node, child)
+              else
+                if ast_node_has_children?(child)
+                  # The AST structure is different for hashes so we have to treat
+                  # them separately.
+                  if ast_hash_node?(child)
+                    xml_hash_node(doc, xml_node, child)
+                  else
+                    xml_array_node(doc, xml_node, child)
+                  end
+                else
+                  xml_node['value'] = child.to_s unless child.nil?
+                end
+              end
+            end
+          end
+          xml_node
+        end
+
+      end
+    end
+  end
+end

--- a/lib/tailor/rulers/indentation_spaces_ruler/line_continuations.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler/line_continuations.rb
@@ -20,7 +20,7 @@ class Tailor
         def line_is_continuation?(lineno)
           @continuations ||= begin
             statements = @ast.xpath('//stmts_add/*[
-              preceding-sibling::stmts_new]')
+              preceding-sibling::stmts_new | preceding-sibling::stmts_add]')
             statements.reject do |stmt|
               s = stmt.xpath('ancestor::stmts_add').size
               stmt.xpath("descendant::pos[count(ancestor::stmts_add) = #{s}]/

--- a/lib/tailor/rulers/indentation_spaces_ruler/line_continuations.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler/line_continuations.rb
@@ -1,0 +1,57 @@
+require 'ripper'
+require_relative './ast_xml'
+
+class Tailor
+  module Rulers
+    class IndentationSpacesRuler < Tailor::Ruler
+
+      # Determines whether a line is a continuation of previous lines. For ease
+      # of implementation we use the s-exp support in Ripper, rather than trying
+      # to work it out solely from the token events on the ruler.
+      class LineContinuations
+
+        include AstXml
+
+        def initialize(file_name)
+          @ast = build_xml(Ripper::SexpBuilder.new(File.read(file_name)).parse)
+        end
+
+        # Is the specified line actually a previous line continuing?
+        def line_is_continuation?(lineno)
+          @continuations ||= begin
+            statements = @ast.xpath('//stmts_add/*[
+              preceding-sibling::stmts_new]')
+            statements.reject do |stmt|
+              s = stmt.xpath('ancestor::stmts_add').size
+              stmt.xpath("descendant::pos[count(ancestor::stmts_add) = #{s}]/
+                @line").map { |s| s.to_s.to_i }.uniq.size < 2
+            end.reject { |stmt| stmt.name == 'case' }.map do |stmt|
+              lines_nesting = lines_with_nesting_level(stmt)
+              lines_nesting.shift
+              min_level = lines_nesting.values.min
+              lines_nesting.reject { |_, n| n > min_level }.keys
+            end.flatten
+          end
+          @continuations.include?(lineno)
+        end
+
+        # Are there statements further nested below this line?
+        def line_has_nested_statements?(lineno)
+          @ast.xpath("//pos[@line='#{lineno}']/
+            ancestor::*[parent::stmts_add][1]/
+            descendant::stmts_add[descendant::pos[@line > #{lineno}]]").any?
+        end
+
+        private
+
+        # Returns a hash of line numbers => nesting level
+        def lines_with_nesting_level(node)
+          Hash[node.xpath('descendant::pos/@line').map do |ln|
+            [ln.to_s.to_i, ln.xpath('count(ancestor::stmts_add)').to_i]
+          end.sort.uniq]
+        end
+
+      end
+    end
+  end
+end

--- a/spec/functional/indentation_spacing/argument_alignment_spec.rb
+++ b/spec/functional/indentation_spacing/argument_alignment_spec.rb
@@ -1,0 +1,511 @@
+require 'spec_helper'
+require_relative '../../support/argument_alignment_cases'
+require 'tailor/critic'
+require 'tailor/configuration/style'
+
+describe 'Argument alignment' do
+
+  def file_name
+    self.class.description
+  end
+
+  def contents
+    ARG_INDENT[file_name] || begin
+      raise "Example not found: #{file_name}"
+    end
+  end
+
+  before do
+    Tailor::Logger.stub(:log)
+    FakeFS.activate!
+    FileUtils.touch file_name
+    File.open(file_name, 'w') { |f| f.write contents }
+  end
+
+  let(:critic) { Tailor::Critic.new }
+
+  let(:style) do
+    style = Tailor::Configuration::Style.new
+    style.trailing_newlines 0, level: :off
+    style.allow_invalid_ruby true, level: :off
+    style
+  end
+
+  context :def_no_arguments do
+
+    it 'does not warn when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :def_arguments_fit_on_one_line do
+
+    it 'does not warn when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :def_arguments_aligned do
+
+    it 'warns when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 14,
+        :message=> "Line is indented to column 14, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'warns when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 14,
+        :message=> "Line is indented to column 14, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :def_arguments_indented do
+
+    it 'does not warn when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'warns when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 2,
+        :message=> "Line is indented to column 2, but should be at 14.",
+        :level=> :error
+      }]
+    end
+
+  end
+
+  context :call_arguments_fit_on_one_line do
+
+    it 'does not warn when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :call_no_arguments do
+
+    it 'does not warn when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :call_arguments_aligned do
+
+    it 'warns when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 49,
+        :message=> "Line is indented to column 49, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'warns when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 49,
+        :message=> "Line is indented to column 49, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :call_arguments_aligned_args_are_integer_literals do
+
+    it 'warns when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 49,
+        :message=> "Line is indented to column 49, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'warns when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 49,
+        :message=> "Line is indented to column 49, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :call_arguments_aligned_args_are_string_literals do
+
+    it 'warns when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 49,
+        :message=> "Line is indented to column 49, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'warns when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 49,
+        :message=> "Line is indented to column 49, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :call_arguments_aligned_multiple_lines do
+
+    it 'warns when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [
+        {
+          :type => 'indentation_spaces',
+          :line => 2,
+          :column=> 49,
+          :message=> "Line is indented to column 49, but should be at 2.",
+          :level=> :error
+        },
+        {
+          :type => 'indentation_spaces',
+          :line => 3,
+          :column=> 49,
+          :message=> "Line is indented to column 49, but should be at 2.",
+          :level=> :error
+        }
+      ]
+    end
+
+    it 'warns when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [
+        {
+          :type => 'indentation_spaces',
+          :line => 2,
+          :column=> 49,
+          :message=> "Line is indented to column 49, but should be at 2.",
+          :level=> :error
+        },
+        {
+          :type => 'indentation_spaces',
+          :line => 3,
+          :column=> 49,
+          :message=> "Line is indented to column 49, but should be at 2.",
+          :level=> :error
+        }
+      ]
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :call_arguments_aligned_args_have_parens do
+    it 'warns when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [
+        {
+          :type => 'indentation_spaces',
+          :line => 2,
+          :column=> 49,
+          :message=> "Line is indented to column 49, but should be at 2.",
+          :level=> :error
+        }
+      ]
+    end
+
+    it 'warns when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [
+        {
+          :type => 'indentation_spaces',
+          :line => 2,
+          :column=> 49,
+          :message=> "Line is indented to column 49, but should be at 2.",
+          :level=> :error
+        }
+      ]
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+
+  end
+
+  context :call_arguments_aligned_no_parens do
+
+    it 'warns when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 49,
+        :message=> "Line is indented to column 49, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'warns when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 49,
+        :message=> "Line is indented to column 49, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :call_arguments_indented do
+
+    it 'does not warn when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'warns when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 2,
+        :message=> "Line is indented to column 2, but should be at 49.",
+        :level=> :error
+      }]
+    end
+
+  end
+
+  context :call_arguments_indented_separate_line do
+
+    it 'does not warn when argument alignment is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :call_arguments_on_next_line do
+
+    it 'does not warn when argument alignment is not specified' do
+      style.indentation_spaces 2, level: :error, line_continuations: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :call_arguments_on_next_line_nested do
+
+    it 'does not warn when argument alignment is not specified' do
+      style.indentation_spaces 2, level: :error, line_continuations: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+  context :call_arguments_on_next_line_multiple do
+
+    it 'does not warn when argument alignment is not specified' do
+      style.indentation_spaces 2, level: :error, line_continuations: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is disabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when argument alignment is enabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+end

--- a/spec/functional/indentation_spacing/line_continuations_spec.rb
+++ b/spec/functional/indentation_spacing/line_continuations_spec.rb
@@ -1,0 +1,182 @@
+require 'spec_helper'
+require_relative '../../support/line_indentation_cases'
+require 'tailor/critic'
+require 'tailor/configuration/style'
+
+describe 'Line continuation indentation' do
+
+  def file_name
+    self.class.description
+  end
+
+  def contents
+    LINE_INDENT[file_name] || begin
+      raise "Example not found: #{file_name}"
+    end
+  end
+
+  before do
+    Tailor::Logger.stub(:log)
+    FakeFS.activate!
+    FileUtils.touch file_name
+    File.open(file_name, 'w') { |f| f.write contents }
+  end
+
+  let(:critic) { Tailor::Critic.new }
+
+  let(:style) do
+    style = Tailor::Configuration::Style.new
+    style.trailing_newlines 0, level: :off
+    style.allow_invalid_ruby true, level: :off
+    style
+  end
+
+  context :line_continues_further_indented do
+
+    it 'warns when line continuation spacing is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 4,
+        :message=> "Line is indented to column 4, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'warns when line continuation spacing is disabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 4,
+        :message=> "Line is indented to column 4, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'does not warn when line continuation spacing is enabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :line_continues_at_same_indentation do
+
+    it 'does not warn when line continuation spacing is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'does not warn when line continuation spacing is disabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'warns when line continuation spacing is enabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 2,
+        :message=> "Line is indented to column 2, but should be at 4.",
+        :level=> :error
+      }]
+    end
+
+  end
+
+  context :parameters_continuation_indent_across_lines do
+    it 'warns when line continuation spacing is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 4,
+        :message=> "Line is indented to column 4, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'warns when line continuation spacing is disabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 4,
+        :message=> "Line is indented to column 4, but should be at 2.",
+        :level=> :error
+      }]
+    end
+
+    it 'warns when line continuation spacing is enabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+  end
+
+  context :parameters_no_continuation_indent_across_lines do
+    it 'warns when line continuation spacing is not specified' do
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'warns when line continuation spacing is disabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: :off
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to be_empty
+    end
+
+    it 'warns when line continuation spacing is enabled' do
+      style.indentation_spaces 2, level: :error, line_continuations: true
+      critic.check_file(file_name, style.to_hash)
+      expect(critic.problems[file_name]).to eql [{
+        :type => 'indentation_spaces',
+        :line => 2,
+        :column=> 2,
+        :message=> "Line is indented to column 2, but should be at 4.",
+        :level=> :error
+      }]
+    end
+
+  end
+
+  [
+    :hash_spans_lines,
+    :if_else,
+    :line_continues_without_nested_statements,
+    :minitest_test_cases,
+    :nested_blocks,
+    :one_assignment_per_line
+  ].each do |never_warns_example|
+      context never_warns_example do
+
+        it 'does not warn when line continuation spacing is not specified' do
+          critic.check_file(file_name, style.to_hash)
+          expect(critic.problems[file_name]).to be_empty
+        end
+
+        it 'does not warn when line continuation spacing is disabled' do
+          style.indentation_spaces 2, level: :error, line_continuations: :off
+          critic.check_file(file_name, style.to_hash)
+          expect(critic.problems[file_name]).to be_empty
+        end
+
+        it 'does not warn when line continuation spacing is enabled' do
+          style.indentation_spaces 2, level: :error, line_continuations: true
+          critic.check_file(file_name, style.to_hash)
+          expect(critic.problems[file_name]).to be_empty
+        end
+
+      end
+    end
+
+end

--- a/spec/support/argument_alignment_cases.rb
+++ b/spec/support/argument_alignment_cases.rb
@@ -1,0 +1,93 @@
+ARG_INDENT = {}
+
+ARG_INDENT['def_no_arguments'] =
+  %q{def foo
+  true
+end}
+
+ARG_INDENT['def_arguments_fit_on_one_line'] =
+  %q{def foo(foo, bar, baz)
+  true
+end}
+
+ARG_INDENT['def_arguments_aligned'] =
+  %q{def something(waka, baka, bing,
+              bla, goop, foop)
+  stuff
+end
+}
+
+ARG_INDENT['def_arguments_indented'] =
+  %q{def something(waka, baka, bing,
+  bla, goop, foop)
+  stuff
+end
+}
+
+ARG_INDENT['call_no_arguments'] =
+  %q{bla = method()}
+
+ARG_INDENT['call_arguments_fit_on_one_line'] =
+  %q{bla = method(foo, bar, baz, bing, ding)}
+
+ARG_INDENT['call_arguments_aligned'] =
+  %q{bla = Something::SomethingElse::SomeClass.method(foo, bar, baz,
+                                                 bing, ding)
+}
+
+ARG_INDENT['call_arguments_aligned_args_are_integer_literals'] =
+  %q{bla = Something::SomethingElse::SomeClass.method(1, 2, 3,
+                                                 4, 5)
+}
+
+ARG_INDENT['call_arguments_aligned_args_are_string_literals'] =
+  %q{bla = Something::SomethingElse::SomeClass.method('foo', 'bar', 'baz',
+                                                 'bing', 'ding')
+}
+
+ARG_INDENT['call_arguments_aligned_args_have_parens'] =
+  %q{bla = Something::SomethingElse::SomeClass.method(foo, bar(), baz,
+                                                 bing, ding)
+}
+
+ARG_INDENT['call_arguments_aligned_no_parens'] =
+  %q{bla = Something::SomethingElse::SomeClass.method foo, bar, baz,
+                                                 bing, ding
+}
+
+ARG_INDENT['call_arguments_aligned_multiple_lines'] =
+  %q{bla = Something::SomethingElse::SomeClass.method(foo, bar, baz,
+                                                 bing, ding,
+                                                 ginb, gind)
+}
+
+ARG_INDENT['call_arguments_indented'] =
+  %q{bla = Something::SomethingElse::SomeClass.method(foo, bar, baz,
+  bing, ding)
+}
+
+ARG_INDENT['call_arguments_indented_separate_line'] =
+  %q{bla = Something::SomethingElse::SomeClass.method(
+  foo, bar, baz,
+  bing, ding
+)}
+
+ARG_INDENT['call_arguments_on_next_line'] =
+  %q{some_long_method_that_goes_out_to_the_end_of_the_line(
+  foo, bar)
+}
+
+ARG_INDENT['call_arguments_on_next_line_nested'] =
+  %q{if some_long_method_that_goes_out_to_the_end_of_the_line(
+    foo, bar)
+  my_nested_expression
+end}
+
+ARG_INDENT['call_arguments_on_next_line_multiple'] =
+  %q{some_long_method_that_goes_out_to_the_end_of_the_line(
+  foo, bar)
+
+if diff_long_method_that_goes_out_to_the_end_of_the_line(
+    foo, bar)
+  my_nested_expression
+end}

--- a/spec/support/line_indentation_cases.rb
+++ b/spec/support/line_indentation_cases.rb
@@ -1,0 +1,71 @@
+LINE_INDENT = {}
+
+LINE_INDENT['hash_spans_lines'] =
+  %q{db_connection = { :host => "localhost", :username => 'root',
+  :password => node['db']['password'] }}
+
+LINE_INDENT['if_else'] =
+  %q{case "foo"
+when "foo"
+  if node["foo"]["version"].to_f >= 5.5
+    default['foo']['service_name'] = "foo"
+    default['foo']['pid_file'] = "/var/run/foo/foo.pid"
+  else
+    default['foo']['service_name'] = "food"
+    default['foo']['pid_file'] = "/var/run/food/food.pid"
+  end
+end}
+
+LINE_INDENT['line_continues_at_same_indentation'] =
+  %q{if someconditional_that == is_really_long.function().stuff() or
+  another_condition == some_thing
+  puts "boop"
+end}
+
+LINE_INDENT['line_continues_further_indented'] =
+  %q{if someconditional_that == is_really_long.function().stuff() or
+    another_condition == some_thing
+  puts "boop"
+end}
+
+LINE_INDENT['line_continues_without_nested_statements'] =
+  %q{attribute "foo/password",
+  :display_name => "Password",
+  :description => "Randomly generated password",
+  :default => "randomly generated"}
+
+LINE_INDENT['minitest_test_cases'] =
+  %q{describe "foo" do
+  it 'includes the disk_free_limit configuration setting' do
+    file("#{node['foo']['config_root']}/foo.config").
+      must_match /\{disk_free_limit, \{mem_relative, #{node['foo']['df']}/
+  end
+  it 'includes the vm_memory_high_watermark configuration setting' do
+    file("#{node['foo']['config_root']}/foo.config").
+      must_match /\{vm_memory_high_watermark, #{node['foo']['vm']}/
+  end
+end}
+
+LINE_INDENT['nested_blocks'] =
+  %q{node['foo']['client']['packages'].each do |foo_pack|
+  package foo_pkg do
+    action :install
+  end
+end}
+
+LINE_INDENT['one_assignment_per_line'] =
+  %q{default['foo']['bar']['apt_key_id'] = 'BD2EFD2A'
+default['foo']['bar']['apt_uri'] = "http://repo.example.com/apt"
+default['foo']['bar']['apt_keyserver'] = "keys.example.net"}
+
+LINE_INDENT['parameters_continuation_indent_across_lines'] =
+  %q{def something(waka, baka, bing,
+    bla, goop, foop)
+  stuff
+end}
+
+LINE_INDENT['parameters_no_continuation_indent_across_lines'] =
+  %q{def something(waka, baka, bing,
+  bla, goop, foop)
+  stuff
+end}

--- a/tailor.gemspec
+++ b/tailor.gemspec
@@ -26,6 +26,7 @@ project, whatever style that may be.
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_runtime_dependency %q<log_switch>, ">= 0.3.0"
+  s.add_runtime_dependency %q<nokogiri>, ">= 1.6.0"
   s.add_runtime_dependency %q<term-ansicolor>, ">= 1.0.5"
   s.add_runtime_dependency %q<text-table>, ">= 1.2.2"
 


### PR DESCRIPTION
Hi Steve,

This pull request builds on #143 to add support for aligning method arguments in f8f3cb3, see #94. I started off by implementing this using the lexer only but again fell back to s-exp's in order to identify method calls that weren't using parentheses.

Cheers,

Andrew.
