### PR TITLE
fix broken regex for indent close

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tailor (1.3.0)
+    tailor (1.3.1)
       log_switch (>= 0.3.0)
       term-ansicolor (>= 1.0.5)
       text-table (>= 1.2.2)
@@ -49,7 +49,7 @@ GEM
     term-ansicolor (1.2.2)
       tins (~> 0.8)
     text-table (1.2.3)
-    tins (0.11.0)
+    tins (0.13.1)
     yard (0.8.7.2)
 
 PLATFORMS

--- a/lib/tailor/rulers/indentation_spaces_ruler.rb
+++ b/lib/tailor/rulers/indentation_spaces_ruler.rb
@@ -67,18 +67,6 @@ class Tailor
       # More info: https://bugs.ruby-lang.org/issues/6211
       def embexpr_end_update(current_lexed_line, lineno, column)
         @embexpr_nesting.pop
-
-        if @manager.multi_line_braces?(lineno)
-          log 'End of multi-line braces!'
-
-          if current_lexed_line.only_embexpr_end?
-            @manager.amount_to_change_this -= 1
-            msg = 'lonely embexpr_end.  '
-            msg << "change_this -= 1 -> #{@manager.amount_to_change_this}"
-            log msg
-          end
-        end
-
         @manager.update_for_closing_reason(:on_embexpr_end, current_lexed_line)
       end
 
@@ -110,7 +98,6 @@ class Tailor
         end
 
         @manager.update_actual_indentation(current_lexed_line)
-        @manager.set_up_line_transition
         measure(lineno, column)
 
         log "indent reasons on exit: #{@manager.indent_reasons}"
@@ -172,8 +159,6 @@ class Tailor
             last[:event_type], current_lexed_line)
         end
 
-        @manager.set_up_line_transition
-
         unless current_lexed_line.end_of_multi_line_string?
           measure(lineno, column)
         end
@@ -205,47 +190,14 @@ class Tailor
           return
         end
 
-        if @manager.multi_line_braces?(lineno)
-          log 'End of multi-line braces!'
-
-          if current_lexed_line.only_rbrace?
-            @manager.amount_to_change_this -= 1
-            msg = 'lonely rbrace.  '
-            msg << "change_this -= 1 -> #{@manager.amount_to_change_this}"
-            log msg
-          end
-        end
-
         @manager.update_for_closing_reason(:on_rbrace, current_lexed_line)
       end
 
       def rbracket_update(current_lexed_line, lineno, column)
-        if @manager.multi_line_brackets?(lineno)
-          log 'End of multi-line brackets!'
-
-          if current_lexed_line.only_rbracket?
-            @manager.amount_to_change_this -= 1
-            msg = 'lonely rbracket.  '
-            msg << "change_this -= 1 -> #{@manager.amount_to_change_this}"
-            log msg
-          end
-        end
-
         @manager.update_for_closing_reason(:on_rbracket, current_lexed_line)
       end
 
       def rparen_update(current_lexed_line, lineno, column)
-        if @manager.multi_line_parens?(lineno)
-          log 'End of multi-line parens!'
-
-          if current_lexed_line.only_rparen?
-            @manager.amount_to_change_this -= 1
-            msg = 'lonely rparen.  '
-            msg << "change_this -= 1 -> #{@manager.amount_to_change_this}"
-            log msg
-          end
-        end
-
         @manager.update_for_closing_reason(:on_rparen, current_lexed_line)
       end
 

--- a/spec/unit/tailor/rulers/indentation_spaces_ruler/indentation_manager_spec.rb
+++ b/spec/unit/tailor/rulers/indentation_spaces_ruler/indentation_manager_spec.rb
@@ -69,17 +69,6 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
     end
   end
 
-  describe '#set_up_line_transition' do
-    context '@amount_to_change_this < 0' do
-      before { subject.instance_variable_set(:@amount_to_change_this, -1) }
-
-      it 'should call #decrease_this_line' do
-        subject.should_receive(:decrease_this_line)
-        subject.set_up_line_transition
-      end
-    end
-  end
-
   describe '#transition_lines' do
     context '#started? is true' do
       before { subject.stub(:started?).and_return true }

--- a/spec/unit/tailor/rulers/indentation_spaces_ruler_spec.rb
+++ b/spec/unit/tailor/rulers/indentation_spaces_ruler_spec.rb
@@ -44,7 +44,7 @@ describe Tailor::Rulers::IndentationSpacesRuler do
 
   describe '#embexpr_end_update' do
     before do
-      lexed_line.should_receive(:only_on_embexpr_end?).and_return(false)
+      lexed_line.should_receive(:only_embexpr_end?).and_return(false)
     end
 
     it 'pops @embexpr_nesting' do


### PR DESCRIPTION
The following code was reported despite being clean:

```
{
  a: 1
}.each do |k, v|
  puts k, v
end
```

This patch fixes the multi-line code path and removes the unneeded line
transition logic from IndentationManager.
