### PR TITLE
Fix Build (RSpec 2 and formatters change)

### DIFF
--- a/lib/tailor/reporter.rb
+++ b/lib/tailor/reporter.rb
@@ -16,11 +16,11 @@ class Tailor
 
       formats.flatten.each do |formatter|
         begin
-          Tailor::Formatters.const_get(formatter.capitalize)
+          eval("Tailor::Formatters::#{formatter.capitalize}")
         rescue NameError
           require_relative "formatters/#{formatter}"
         ensure
-          @formatters << Tailor::Formatters.const_get(formatter.capitalize).new
+          @formatters << eval("Tailor::Formatters::#{formatter.capitalize}").new
         end
       end
     end

--- a/tailor.gemspec
+++ b/tailor.gemspec
@@ -36,8 +36,7 @@ project, whatever style that may be.
   s.add_development_dependency 'cucumber', '>= 1.0.2'
   s.add_development_dependency 'fakefs', '>= 0.4.2'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '>= 2.5.0'
+  s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'simplecov', '>= 0.4.0'
   s.add_development_dependency 'yard', '>= 0.7.0'
 end
-


### PR DESCRIPTION
This PR does two things:
- set RSpec to 2.14 (since there are some non-RSpec 3 specs)
- use `eval` instead of `const_get` for formatters lookup.

After setting the RSpec version, I noticed that some formatter tests were failing because the `const_get` call was finding the `Text` module instead of the `Tailor::Formatters:Text` class. `Text` appears to be from another gem and is used [here](https://github.com/turboladen/tailor/blob/master/lib/tailor/configuration.rb#L224).
