### PR TITLE
pin log_switch as the 1.0.0 release of log_switch breaks tailor

### DIFF
--- a/tailor.gemspec
+++ b/tailor.gemspec
@@ -26,7 +26,7 @@ project, whatever style that may be.
   s.test_files = `git ls-files -- {spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  s.add_runtime_dependency 'log_switch', '>= 0.3.0'
+  s.add_runtime_dependency 'log_switch', '= 0.3.0' # log_switch 1.0.0 isn't compatable
   s.add_runtime_dependency 'nokogiri', '>= 1.6.0'
   s.add_runtime_dependency 'term-ansicolor', '>= 1.0.5'
   s.add_runtime_dependency 'text-table', '>= 1.2.2'


### PR DESCRIPTION
This should only be temp, but as of log_switch 1.0.0 LogSwitch::Mixin
no longer exists.
