### PR TITLE
Lock log_switch to ~> 0.3.0, spec updates, style cleanup

### DIFF
--- a/features/step_definitions/indentation_steps.rb
+++ b/features/step_definitions/indentation_steps.rb
@@ -1,6 +1,6 @@
 Given /^(.+) exists with(\w*) a newline at the end$/ do |file_name, no_newline|
   file_contents = get_file_contents(file_name)
-  file_contents.should_not be_nil
+  expect(file_contents).to_not be_nil
 
   if no_newline.empty?
     file_contents << "\n" unless file_contents[-1] == "\n"

--- a/lib/tailor/reporter.rb
+++ b/lib/tailor/reporter.rb
@@ -1,5 +1,4 @@
 class Tailor
-
   # Objects of this type are responsible for sending the right data to report
   # formatters.
   class Reporter

--- a/lib/tailor/rulers/spaces_before_lbrace_ruler.rb
+++ b/lib/tailor/rulers/spaces_before_lbrace_ruler.rb
@@ -2,7 +2,6 @@ require_relative '../ruler'
 
 class Tailor
   module Rulers
-
     # Detects spaces before a +{+ as given by +@config+.  It skips checking
     # when:
     # * it's the first char in the line.

--- a/lib/tailor/rulers/spaces_before_rbrace_ruler.rb
+++ b/lib/tailor/rulers/spaces_before_rbrace_ruler.rb
@@ -2,7 +2,6 @@ require_relative '../ruler'
 
 class Tailor
   module Rulers
-
     # Checks for spaces before a +}+ as given by +@config+.  It skips checking
     # when:
     # * it's the first char in the line.

--- a/lib/tailor/rulers/spaces_in_empty_braces_ruler.rb
+++ b/lib/tailor/rulers/spaces_in_empty_braces_ruler.rb
@@ -2,7 +2,6 @@ require_relative '../ruler'
 
 class Tailor
   module Rulers
-
     # Checks for spaces that exist between a +{+ and +}+ when there is only
     # space in between them.
     class SpacesInEmptyBracesRuler < Tailor::Ruler

--- a/spec/functional/conditional_parentheses_spec.rb
+++ b/spec/functional/conditional_parentheses_spec.rb
@@ -16,7 +16,7 @@ describe 'Conditional parentheses' do
   end
 
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     FileUtils.touch file_name
     File.open(file_name, 'w') { |f| f.write contents }

--- a/spec/functional/conditional_spacing_spec.rb
+++ b/spec/functional/conditional_spacing_spec.rb
@@ -16,7 +16,7 @@ describe 'Conditional spacing' do
   end
 
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     FileUtils.touch file_name
     File.open(file_name, 'w') { |f| f.write contents }

--- a/spec/functional/configuration_spec.rb
+++ b/spec/functional/configuration_spec.rb
@@ -1,10 +1,9 @@
 require 'spec_helper'
 require 'tailor/configuration'
 
-
 describe 'Config File' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.deactivate!
   end
 
@@ -22,15 +21,16 @@ describe 'Config File' do
 
     context '.tailor does not exist' do
       before do
-        Tailor::Configuration.any_instance.stub(:config_file).and_return false
+        allow_any_instance_of(Tailor::Configuration).to receive(:config_file).
+          and_return false
       end
 
       it "sets formatters to 'text'" do
-        config.formatters.should == %w(text)
+        expect(config.formatters).to eq %w(text)
       end
 
       it 'sets file_sets[:default].style to the default style' do
-        config.file_sets[:default].style.should_not be_nil
+        expect(config.file_sets[:default].style).to_not be_nil
         expect(config.file_sets[:default].style).
           to eq Tailor::Configuration::Style.new.to_hash
       end
@@ -57,11 +57,13 @@ end
         end
 
         before do
-          File.should_receive(:read).and_return config_file
+          expect(File).to receive(:read).and_return config_file
         end
 
         it 'creates the default file set' do
-          config.file_sets[:default].style.should == Tailor::Configuration::Style.new.to_hash
+          expect(config.file_sets[:default].style).
+            to eq Tailor::Configuration::Style.new.to_hash
+
           expect(config.file_sets[:default].file_list.all? do |path|
             path =~ /tailor\/lib/
           end).to eq true
@@ -70,7 +72,7 @@ end
         it 'creates the :features file set' do
           style = Tailor::Configuration::Style.new
           style.max_line_length(90, level: :warn)
-          config.file_sets[:features].style.should == style.to_hash
+          expect(config.file_sets[:features].style).to eq style.to_hash
           expect(config.file_sets[:features].file_list.all? do |path|
             path =~ /features/
           end).to eq true
@@ -90,15 +92,15 @@ end
       end
 
       before do
-        File.should_receive(:read).and_return config_file
+        expect(File).to receive(:read).and_return config_file
       end
 
       it 'does not create a :default file set' do
-        config.file_sets.should_not include :default
+        expect(config.file_sets).to_not include :default
       end
 
       it 'creates the non-default file set' do
-        config.file_sets.should include :features
+        expect(config.file_sets).to include :features
       end
     end
 
@@ -114,11 +116,11 @@ end
       end
 
       before do
-        File.should_receive(:read).and_return config_file
+        expect(File).to receive(:read).and_return config_file
       end
 
       it 'creates a :default file set' do
-        config.file_sets.keys.should == [:default]
+        expect(config.file_sets.keys).to eq [:default]
       end
 
       it 'has files in the file list levels deep' do
@@ -145,21 +147,24 @@ end
 
     context '.tailor does not exist' do
       before do
-        Tailor::Configuration.any_instance.stub(:config_file).and_return false
+        allow_any_instance_of(Tailor::Configuration).
+          to receive(:config_file).and_return false
       end
 
       it "sets formatters to 'text'" do
-        config.formatters.should == %w(text)
+        expect(config.formatters).to eq %w(text)
       end
 
       it 'sets file_sets[:default].style to the default style' do
-        config.file_sets[:default].style.should_not be_nil
-        config.file_sets[:default].style.should == Tailor::Configuration::Style.new.to_hash
+        expect(config.file_sets[:default].style).to_not be_nil
+        expect(config.file_sets[:default].style).
+          to eq Tailor::Configuration::Style.new.to_hash
       end
 
       it 'sets file_sets[:default].file_list to the runtime files' do
-        config.file_sets[:default].file_list.size.should be 1
-        config.file_sets[:default].file_list.first.match /lib\/tailor\.rb$/
+        expect(config.file_sets[:default].file_list.size).to eq 1
+        expect(config.file_sets[:default].file_list.first).
+          to match(/lib\/tailor\.rb$/)
       end
     end
 
@@ -180,19 +185,20 @@ end
         end
 
         before do
-          File.should_receive(:read).and_return config_file
+          expect(File).to receive(:read).and_return config_file
         end
 
         it 'creates the default file set using the runtime files' do
           style = Tailor::Configuration::Style.new
           style.max_line_length 85
-          config.file_sets[:default].style.should == style.to_hash
-          config.file_sets[:default].file_list.size.should be 1
-          config.file_sets[:default].file_list.first.match /lib\/tailor\.rb$/
+          expect(config.file_sets[:default].style).to eq style.to_hash
+          expect(config.file_sets[:default].file_list.size).to eq 1
+          expect(config.file_sets[:default].file_list.first).
+            to match(/lib\/tailor\.rb$/)
         end
 
         it 'does not create the :features file set' do
-          config.file_sets.should_not include :features
+          expect(config.file_sets).to_not include :features
         end
       end
     end
@@ -209,17 +215,19 @@ end
       end
 
       before do
-        File.should_receive(:read).and_return config_file
+        expect(File).to receive(:read).and_return config_file
       end
 
-      it 'creates a :default file set with the runtime file and default style' do
-        config.file_sets[:default].style.should == Tailor::Configuration::Style.new.to_hash
-        config.file_sets[:default].file_list.size.should be 1
-        config.file_sets[:default].file_list.first.match /lib\/tailor\.rb$/
+      it 'creates a :default file set with the runtime file & default style' do
+        expect(config.file_sets[:default].style).
+          to eq Tailor::Configuration::Style.new.to_hash
+        expect(config.file_sets[:default].file_list.size).to eq 1
+        expect(config.file_sets[:default].file_list.first).
+          to match(/lib\/tailor\.rb$/)
       end
 
       it 'does not create the non-default file set' do
-        config.file_sets.should_not include :features
+        expect(config.file_sets).to_not include :features
       end
     end
 
@@ -235,20 +243,21 @@ end
       end
 
       before do
-        File.should_receive(:read).and_return config_file
+        expect(File).to receive(:read).and_return config_file
       end
 
       it 'creates a :default file set' do
-        config.file_sets.keys.should == [:default]
+        expect(config.file_sets.keys).to eq [:default]
       end
 
-      it 'creates a :default file set with the runtime file and default style' do
-        style = Tailor::Configuration::Style.new.tap do |style|
-          style.max_line_length 90, level: :warn
+      it 'creates a :default file set with the runtime file & default style' do
+        style = Tailor::Configuration::Style.new.tap do |s|
+          s.max_line_length 90, level: :warn
         end.to_hash
-        config.file_sets[:default].style.should == style
-        config.file_sets[:default].file_list.size.should be 1
-        config.file_sets[:default].file_list.first.match /lib\/tailor\.rb$/
+        expect(config.file_sets[:default].style).to eq style
+        expect(config.file_sets[:default].file_list.size).to eq 1
+        expect(config.file_sets[:default].file_list.first).
+          to match(/lib\/tailor\.rb$/)
       end
     end
 
@@ -262,11 +271,11 @@ end
       end
 
       before do
-        File.should_receive(:read).and_return config_file
+        expect(File).to receive(:read).and_return config_file
       end
 
       it "sets formatters to 'yaml'" do
-        config.formatters.should == %w(yaml)
+        expect(config.formatters).to eq %w(yaml)
       end
     end
 
@@ -280,13 +289,12 @@ end
       end
 
       before do
-        File.should_receive(:read).and_return config_file
+        expect(File).to receive(:read).and_return config_file
       end
 
       it 'sets formatters to the defined' do
-        config.formatters.should == %w(yaml text)
+        expect(config.formatters).to eq %w(yaml text)
       end
-
     end
   end
 end

--- a/spec/functional/configuration_spec.rb
+++ b/spec/functional/configuration_spec.rb
@@ -31,13 +31,14 @@ describe 'Config File' do
 
       it 'sets file_sets[:default].style to the default style' do
         config.file_sets[:default].style.should_not be_nil
-        config.file_sets[:default].style.should == Tailor::Configuration::Style.new.to_hash
+        expect(config.file_sets[:default].style).
+          to eq Tailor::Configuration::Style.new.to_hash
       end
 
       it 'sets file_sets[:default].file_list to the files in lib/**/*.rb' do
-        config.file_sets[:default].file_list.all? do |path|
+        expect(config.file_sets[:default].file_list.all? do |path|
           path =~ /tailor\/lib/
-        end.should be_true
+        end).to eq true
       end
     end
 
@@ -61,18 +62,18 @@ end
 
         it 'creates the default file set' do
           config.file_sets[:default].style.should == Tailor::Configuration::Style.new.to_hash
-          config.file_sets[:default].file_list.all? do |path|
+          expect(config.file_sets[:default].file_list.all? do |path|
             path =~ /tailor\/lib/
-          end.should be_true
+          end).to eq true
         end
 
         it 'creates the :features file set' do
           style = Tailor::Configuration::Style.new
           style.max_line_length(90, level: :warn)
           config.file_sets[:features].style.should == style.to_hash
-          config.file_sets[:features].file_list.all? do |path|
+          expect(config.file_sets[:features].file_list.all? do |path|
             path =~ /features/
-          end.should be_true
+          end).to eq true
         end
       end
     end
@@ -121,9 +122,9 @@ end
       end
 
       it 'has files in the file list levels deep' do
-        config.file_sets[:default].file_list.all? do |file|
+        expect(config.file_sets[:default].file_list.all? do |file|
           file =~ /spec\.rb$/
-        end.should be_true
+        end).to eq true
       end
 
       it 'applies the nested configuration within the fileset' do

--- a/spec/functional/horizontal_spacing/braces_spec.rb
+++ b/spec/functional/horizontal_spacing/braces_spec.rb
@@ -4,58 +4,58 @@ require 'tailor/configuration/style'
 
 BRACES = {}
 BRACES['single_line_hash_0_spaces_before_lbrace'] =
-  %Q{thing ={ :one => 'one' }}
+  %(thing ={ :one => 'one' })
 
 BRACES['single_line_hash_2_spaces_before_lbrace'] =
-  %Q{thing =  { :one => 'one' }}
+  %(thing =  { :one => 'one' })
 
 BRACES['single_line_hash_2_spaces_before_rbrace'] =
-  %Q{thing = { :one => 'one'  }}
+  %(thing = { :one => 'one'  })
 
 BRACES['single_line_hash_2_spaces_after_lbrace'] =
-  %Q{thing = {  :one => 'one' }}
+  %(thing = {  :one => 'one' })
 
-BRACES['two_line_hash_2_spaces_before_lbrace'] = %Q{thing1 =
-  thing2 =  { :one => 'one' }}
+BRACES['two_line_hash_2_spaces_before_lbrace'] = %(thing1 =
+  thing2 =  { :one => 'one' })
 
-BRACES['two_line_hash_2_spaces_before_rbrace'] = %Q{thing1 =
-  thing2 = { :one => 'one'  }}
+BRACES['two_line_hash_2_spaces_before_rbrace'] = %(thing1 =
+  thing2 = { :one => 'one'  })
 
 BRACES['two_line_hash_2_spaces_before_lbrace_lonely_braces'] =
-  %Q{thing1 =
+  %(thing1 =
   thing2 =  {
     :one => 'one'
-  }}
+  })
 
 BRACES['space_in_empty_hash_in_string_in_block'] =
-  %Q{[1].map { |n| { :first => "\#{n}-\#{{ }}" } }}
+  %([1].map { |n| { :first => "\#{n}-\#{{ }}" } })
 
 BRACES['single_line_block_2_spaces_before_lbrace'] =
-  %Q{1..10.times  { |n| puts n }}
+  %(1..10.times  { |n| puts n })
 
 BRACES['single_line_block_in_string_interp_2_spaces_before_lbrace'] =
-  %Q{"I did this \#{1..10.times  { |n| puts n }} times."}
+  %("I did this \#{1..10.times  { |n| puts n }} times.")
 
 BRACES['single_line_block_0_spaces_before_lbrace'] =
-  %Q{1..10.times{ |n| puts n }}
+  %(1..10.times{ |n| puts n })
 
 BRACES['two_line_braces_block_2_spaces_before_lbrace'] =
-  %Q{1..10.times  { |n|
-  puts n}}
+  %(1..10.times  { |n|
+  puts n})
 
 BRACES['two_line_braces_block_0_spaces_before_lbrace_trailing_comment'] =
-  %Q{1..10.times{ |n|    # comment
-  puts n}}
+  %(1..10.times{ |n|    # comment
+  puts n})
 
 BRACES['no_space_after_l_before_r_after_string_interp'] =
-  %Q{logger.debug "from \#{current} to \#{new_ver}", {:format => :short}}
+  %(logger.debug "from \#{current} to \#{new_ver}", {:format => :short})
 
 BRACES['no_space_before_consecutive_rbraces'] =
-  %Q{thing = { 'id' => "\#{source}", 'attributes' => { 'height' => "\#{height}"}}}
+  %(thing = { 'id' => "\#{source}", 'attributes' => { 'height' => "\#{height}"}})
 
-describe "Detection of spacing around braces" do
+describe 'Detection of spacing around braces' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     File.open(file_name, 'w') { |f| f.write contents }
     critic.check_file(file_name, style.to_hash)
@@ -65,7 +65,7 @@ describe "Detection of spacing around braces" do
     Tailor::Critic.new
   end
 
-  let(:contents) { BRACES[file_name]}
+  let(:contents) { BRACES[file_name] }
 
   let(:style) do
     style = Tailor::Configuration::Style.new
@@ -75,165 +75,165 @@ describe "Detection of spacing around braces" do
     style
   end
 
-  context "single-line Hash" do
-    context "0 spaces before lbrace" do
+  context 'single-line Hash' do
+    context '0 spaces before lbrace' do
       let!(:file_name) { 'single_line_hash_0_spaces_before_lbrace' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_before_lbrace" }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 7 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_lbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 7 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
-    context "2 spaces before lbrace" do
+    context '2 spaces before lbrace' do
       let!(:file_name) { 'single_line_hash_2_spaces_before_lbrace' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_before_lbrace" }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 9 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_lbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 9 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
-    context "2 spaces after lbrace" do
+    context '2 spaces after lbrace' do
       let!(:file_name) { 'single_line_hash_2_spaces_after_lbrace' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_after_lbrace" }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 9 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_lbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 9 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
-    context "2 spaces before rbrace" do
+    context '2 spaces before rbrace' do
       let!(:file_name) { 'single_line_hash_2_spaces_before_rbrace' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_before_rbrace" }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 25 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_rbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 25 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
-  context "two-line Hash" do
-    context "2 spaces before lbrace" do
+  context 'two-line Hash' do
+    context '2 spaces before lbrace' do
       let!(:file_name) { 'two_line_hash_2_spaces_before_lbrace' }
-      specify { critic.problems[file_name.to_s].size.should be 1 }
-      specify { critic.problems[file_name.to_s].first[:type].should == "spaces_before_lbrace" }
-      specify { critic.problems[file_name.to_s].first[:line].should be 2 }
-      specify { critic.problems[file_name.to_s].first[:column].should be 12 }
-      specify { critic.problems[file_name.to_s].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_lbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 12 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
-    context "2 spaces before rbrace" do
+    context '2 spaces before rbrace' do
       let!(:file_name) { 'two_line_hash_2_spaces_before_rbrace' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_before_rbrace" }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 28 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_rbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 28 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
-    context "2 spaces before lbrace, lonely braces" do
+    context '2 spaces before lbrace, lonely braces' do
       let!(:file_name) { 'two_line_hash_2_spaces_before_lbrace_lonely_braces' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_before_lbrace" }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 12 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_lbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 12 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
-  context "single-line block" do
-    context "space in empty Hash" do
+  context 'single-line block' do
+    context 'space in empty Hash' do
       let!(:file_name) { 'space_in_empty_hash_in_string_in_block' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_in_empty_braces" }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 36 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_in_empty_braces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 36 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
-    context "0 spaces before lbrace" do
+    context '0 spaces before lbrace' do
       let!(:file_name) { 'single_line_block_0_spaces_before_lbrace' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_before_lbrace" }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 11 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_lbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 11 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
-    context "2 spaces before lbrace" do
+    context '2 spaces before lbrace' do
       let!(:file_name) { 'single_line_block_2_spaces_before_lbrace' }
-      specify { critic.problems[file_name.to_s].size.should be 1 }
-      specify { critic.problems[file_name.to_s].first[:type].should == "spaces_before_lbrace" }
-      specify { critic.problems[file_name.to_s].first[:line].should be 1 }
-      specify { critic.problems[file_name.to_s].first[:column].should be 13 }
-      specify { critic.problems[file_name.to_s].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_lbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 13 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
-    context "in String interpolation, 2 spaces before lbrace" do
+    context 'in String interpolation, 2 spaces before lbrace' do
       let!(:file_name) { 'single_line_block_in_string_interp_2_spaces_before_lbrace' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_before_lbrace" }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 27 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_lbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 27 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
-  context "multi-line block" do
-    context "2 spaces before lbrace" do
+  context 'multi-line block' do
+    context '2 spaces before lbrace' do
       let!(:file_name) { 'two_line_braces_block_2_spaces_before_lbrace' }
-      specify { critic.problems[file_name].size.should be 2 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_before_lbrace" }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 13 }
-      specify { critic.problems[file_name].first[:level].should be :error }
-      specify { critic.problems[file_name].last[:type].should == "spaces_before_rbrace" }
-      specify { critic.problems[file_name].last[:line].should be 2 }
-      specify { critic.problems[file_name].last[:column].should be 8 }
-      specify { critic.problems[file_name].last[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_lbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 13 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
+      specify { expect(critic.problems[file_name].last[:type]).to eq 'spaces_before_rbrace' }
+      specify { expect(critic.problems[file_name].last[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].last[:column]).to eq 8 }
+      specify { expect(critic.problems[file_name].last[:level]).to eq :error }
     end
 
-    context "0 spaces before lbrace, with trailing comment" do
+    context '0 spaces before lbrace, with trailing comment' do
       let!(:file_name) { 'two_line_braces_block_0_spaces_before_lbrace_trailing_comment' }
-      specify { critic.problems[file_name].size.should be 2 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_before_lbrace" }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 11 }
-      specify { critic.problems[file_name].first[:level].should be :error }
-      specify { critic.problems[file_name].last[:type].should == "spaces_before_rbrace" }
-      specify { critic.problems[file_name].last[:line].should be 2 }
-      specify { critic.problems[file_name].last[:column].should be 8 }
-      specify { critic.problems[file_name].last[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_lbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 11 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
+      specify { expect(critic.problems[file_name].last[:type]).to eq 'spaces_before_rbrace' }
+      specify { expect(critic.problems[file_name].last[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].last[:column]).to eq 8 }
+      specify { expect(critic.problems[file_name].last[:level]).to eq :error }
     end
   end
 
-  context "String interpolation" do
-    context "0 spaces after lbrace or before rbrace" do
+  context 'String interpolation' do
+    context '0 spaces after lbrace or before rbrace' do
       let!(:file_name) { 'no_space_after_l_before_r_after_string_interp' }
-      specify { critic.problems[file_name].size.should be 2 }
-      specify { critic.problems[file_name].first[:type].should == "spaces_after_lbrace" }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 47 }
-      specify { critic.problems[file_name].first[:level].should be :error }
-      specify { critic.problems[file_name].last[:type].should == "spaces_before_rbrace" }
-      specify { critic.problems[file_name].last[:line].should be 1 }
-      specify { critic.problems[file_name].last[:column].should be 64 }
-      specify { critic.problems[file_name].last[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_lbrace' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 47 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
+      specify { expect(critic.problems[file_name].last[:type]).to eq 'spaces_before_rbrace' }
+      specify { expect(critic.problems[file_name].last[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].last[:column]).to eq 64 }
+      specify { expect(critic.problems[file_name].last[:level]).to eq :error }
     end
 
-    context "no space before consecutive rbraces" do
+    context 'no space before consecutive rbraces' do
       let(:file_name) { 'no_space_before_consecutive_rbraces' }
       let(:problems) { critic.problems[file_name].select { |p| p[:type] == 'spaces_before_rbrace' } }
-      specify { problems.size.should be 2 }
-      specify { problems.first[:type].should == "spaces_before_rbrace" }
-      specify { problems.first[:line].should be 1 }
-      specify { problems.first[:column].should be 72 }
-      specify { problems.first[:level].should be :error }
-      specify { problems.last[:type].should == "spaces_before_rbrace" }
-      specify { problems.last[:line].should be 1 }
-      specify { problems.last[:column].should be 73 }
-      specify { problems.last[:level].should be :error }
+      specify { expect(problems.size).to eq 2 }
+      specify { expect(problems.first[:type]).to eq 'spaces_before_rbrace' }
+      specify { expect(problems.first[:line]).to eq 1 }
+      specify { expect(problems.first[:column]).to eq 72 }
+      specify { expect(problems.first[:level]).to eq :error }
+      specify { expect(problems.last[:type]).to eq 'spaces_before_rbrace' }
+      specify { expect(problems.last[:line]).to eq 1 }
+      specify { expect(problems.last[:column]).to eq 73 }
+      specify { expect(problems.last[:level]).to eq :error }
     end
   end
 end

--- a/spec/functional/horizontal_spacing/brackets_spec.rb
+++ b/spec/functional/horizontal_spacing/brackets_spec.rb
@@ -2,22 +2,20 @@ require 'spec_helper'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 BRACKETS = {}
-BRACKETS['space_in_empty_array'] = %Q{[ ]}
-BRACKETS['simple_array_space_after_lbracket'] = %Q{[ 1, 2, 3]}
-BRACKETS['simple_array_space_before_rbracket'] = %Q{[1, 2, 3 ]}
-BRACKETS['hash_key_ref_space_before_rbracket'] = %Q{thing[:one ]}
-BRACKETS['hash_key_ref_space_after_lbracket'] = %Q{thing[ :one]}
+BRACKETS['space_in_empty_array'] = %([ ])
+BRACKETS['simple_array_space_after_lbracket'] = %([ 1, 2, 3])
+BRACKETS['simple_array_space_before_rbracket'] = %([1, 2, 3 ])
+BRACKETS['hash_key_ref_space_before_rbracket'] = %(thing[:one ])
+BRACKETS['hash_key_ref_space_after_lbracket'] = %(thing[ :one])
 BRACKETS['two_d_array_space_after_lbrackets'] =
-  %Q{[ [1, 2, 3], [ 'a', 'b', 'c']]}
+  %([ [1, 2, 3], [ 'a', 'b', 'c']])
 BRACKETS['two_d_array_space_before_rbrackets'] =
-  %Q{[[1, 2, 3 ], [ 'a', 'b', 'c'] ]}
-
+  %([[1, 2, 3 ], [ 'a', 'b', 'c'] ])
 
 describe 'Detection of spaces around brackets' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     File.open(file_name, 'w') { |f| f.write contents }
     critic.check_file(file_name, style.to_hash)
@@ -27,7 +25,7 @@ describe 'Detection of spaces around brackets' do
     Tailor::Critic.new
   end
 
-  let(:contents) { BRACKETS[file_name]}
+  let(:contents) { BRACKETS[file_name] }
 
   let(:style) do
     style = Tailor::Configuration::Style.new
@@ -40,49 +38,49 @@ describe 'Detection of spaces around brackets' do
   context 'Arrays' do
     context 'empty with space inside' do
       let(:file_name) { 'space_in_empty_array' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'spaces_after_lbracket' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_lbracket' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'space after lbracket' do
       let(:file_name) { 'simple_array_space_after_lbracket' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'spaces_after_lbracket' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_lbracket' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'space before rbracket' do
       let(:file_name) { 'simple_array_space_before_rbracket' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'spaces_before_rbracket' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 9 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_rbracket' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 9 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
   context 'Hash key references' do
     context 'space before rbracket' do
       let(:file_name) { 'hash_key_ref_space_before_rbracket' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'spaces_before_rbracket' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 11 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_rbracket' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 11 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'space after lbracket' do
       let(:file_name) { 'hash_key_ref_space_after_lbracket' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'spaces_after_lbracket' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 6 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_lbracket' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 6 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 end

--- a/spec/functional/horizontal_spacing/comma_spacing_spec.rb
+++ b/spec/functional/horizontal_spacing/comma_spacing_spec.rb
@@ -2,24 +2,22 @@ require 'spec_helper'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 COMMA_SPACING = {}
-COMMA_SPACING['no_space_after_comma'] = %Q{[1,2]}
-COMMA_SPACING['two_spaces_after_comma'] = %Q{[1,  2]}
-COMMA_SPACING['one_space_before_comma'] = %Q{[1 , 2]}
-COMMA_SPACING['two_spaces_before_comma'] = %Q{[1  , 2]}
-COMMA_SPACING['two_spaces_before_comma_twice'] = %Q{[1  , 2  , 3]}
-COMMA_SPACING['two_spaces_after_comma_twice'] = %Q{[1,  2,  3]}
+COMMA_SPACING['no_space_after_comma'] = %([1,2])
+COMMA_SPACING['two_spaces_after_comma'] = %([1,  2])
+COMMA_SPACING['one_space_before_comma'] = %([1 , 2])
+COMMA_SPACING['two_spaces_before_comma'] = %([1  , 2])
+COMMA_SPACING['two_spaces_before_comma_twice'] = %([1  , 2  , 3])
+COMMA_SPACING['two_spaces_after_comma_twice'] = %([1,  2,  3])
 
-COMMA_SPACING['spaces_before_with_trailing_comments'] = %Q{[
+COMMA_SPACING['spaces_before_with_trailing_comments'] = %([
   1 ,   # Comment!
   2 ,   # Another comment.
-}
-
+)
 
 describe 'Spacing around comma detection' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     File.open(file_name, 'w') { |f| f.write contents }
     critic.check_file(file_name, style.to_hash)
@@ -29,7 +27,7 @@ describe 'Spacing around comma detection' do
     Tailor::Critic.new
   end
 
-  let(:contents) { COMMA_SPACING[file_name]}
+  let(:contents) { COMMA_SPACING[file_name] }
 
   let(:style) do
     style = Tailor::Configuration::Style.new
@@ -41,28 +39,28 @@ describe 'Spacing around comma detection' do
 
   context 'no space after a comma' do
     let(:file_name) { 'no_space_after_comma' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'spaces_after_comma' }
-    specify { critic.problems[file_name].first[:line].should be 1 }
-    specify { critic.problems[file_name].first[:column].should be 3 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_comma' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 
   context 'two spaces after a comma' do
     let(:file_name) { 'two_spaces_after_comma' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'spaces_after_comma' }
-    specify { critic.problems[file_name].first[:line].should be 1 }
-    specify { critic.problems[file_name].first[:column].should be 3 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_comma' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 
   context 'one space before comma' do
     let(:file_name) { 'one_space_before_comma' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'spaces_before_comma' }
-    specify { critic.problems[file_name].first[:line].should be 1 }
-    specify { critic.problems[file_name].first[:column].should be 2 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_comma' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 2 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 end

--- a/spec/functional/horizontal_spacing/hard_tabs_spec.rb
+++ b/spec/functional/horizontal_spacing/hard_tabs_spec.rb
@@ -8,16 +8,16 @@ require 'tailor/configuration/style'
 HARD_TABS = {}
 
 HARD_TABS['hard_tab'] =
-  %Q{def something
+  %(def something
 \tputs 'something'
-end}
+end)
 
 HARD_TABS['hard_tab_with_spaces'] =
-  %Q{class Thing
+  %(class Thing
   def something
 \t  puts 'something'
   end
-end}
+end)
 
 # This only reports the hard tab problem (and not the indentation problem)
 # because a hard tab is counted as 1 space; here, this is 4 spaces, so it
@@ -25,22 +25,22 @@ end}
 # hard tab should signal the problem.  If you fix the hard tab and don't
 # fix indentation, tailor will flag you on the indentation on the next run.
 HARD_TABS['hard_tab_with_1_indented_space'] =
-  %Q{class Thing
+  %(class Thing
   def something
 \t   puts 'something'
   end
-end}
+end)
 
 HARD_TABS['hard_tab_with_2_indented_spaces'] =
-  %Q{class Thing
+  %(class Thing
   def something
 \t    puts 'something'
   end
-end}
+end)
 
 describe 'Hard tab detection' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     File.open(file_name, 'w') { |f| f.write contents }
     critic.check_file(file_name, style.to_hash)
@@ -50,7 +50,7 @@ describe 'Hard tab detection' do
     Tailor::Critic.new
   end
 
-  let(:contents) { HARD_TABS[file_name]}
+  let(:contents) { HARD_TABS[file_name] }
 
   let(:style) do
     style = Tailor::Configuration::Style.new
@@ -62,49 +62,49 @@ describe 'Hard tab detection' do
 
   context '1 hard tab' do
     let(:file_name) { 'hard_tab' }
-    specify { critic.problems[file_name].size.should be 2 }
-    specify { critic.problems[file_name].first[:type].should == 'allow_hard_tabs' }
-    specify { critic.problems[file_name].first[:line].should be 2 }
-    specify { critic.problems[file_name].first[:column].should be 0 }
-    specify { critic.problems[file_name].first[:level].should be :error }
-    specify { critic.problems[file_name].last[:type].should == 'indentation_spaces' }
-    specify { critic.problems[file_name].last[:line].should be 2 }
-    specify { critic.problems[file_name].last[:column].should be 1 }
-    specify { critic.problems[file_name].last[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 2 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'allow_hard_tabs' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 0 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
+    specify { expect(critic.problems[file_name].last[:type]).to eq 'indentation_spaces' }
+    specify { expect(critic.problems[file_name].last[:line]).to eq 2 }
+    specify { expect(critic.problems[file_name].last[:column]).to eq 1 }
+    specify { expect(critic.problems[file_name].last[:level]).to eq :error }
   end
 
   context '1 hard tab with 2 spaces after it' do
     let(:file_name) { 'hard_tab_with_spaces' }
-    specify { critic.problems[file_name].size.should be 2 }
-    specify { critic.problems[file_name].first[:type].should == 'allow_hard_tabs' }
-    specify { critic.problems[file_name].first[:line].should be 3 }
-    specify { critic.problems[file_name].first[:column].should be 0 }
-    specify { critic.problems[file_name].first[:level].should be :error }
-    specify { critic.problems[file_name].last[:type].should == 'indentation_spaces' }
-    specify { critic.problems[file_name].last[:line].should be 3 }
-    specify { critic.problems[file_name].last[:column].should be 3 }
-    specify { critic.problems[file_name].last[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 2 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'allow_hard_tabs' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 0 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
+    specify { expect(critic.problems[file_name].last[:type]).to eq 'indentation_spaces' }
+    specify { expect(critic.problems[file_name].last[:line]).to eq 3 }
+    specify { expect(critic.problems[file_name].last[:column]).to eq 3 }
+    specify { expect(critic.problems[file_name].last[:level]).to eq :error }
   end
 
   context '1 hard tab with 3 spaces after it' do
     let(:file_name) { 'hard_tab_with_1_indented_space' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'allow_hard_tabs' }
-    specify { critic.problems[file_name].first[:line].should be 3 }
-    specify { critic.problems[file_name].first[:column].should be 0 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'allow_hard_tabs' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 0 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 
   context '1 hard tab with 4 spaces after it' do
     let(:file_name) { 'hard_tab_with_2_indented_spaces' }
-    specify { critic.problems[file_name].size.should be 2 }
-    specify { critic.problems[file_name].first[:type].should == 'allow_hard_tabs' }
-    specify { critic.problems[file_name].first[:line].should be 3 }
-    specify { critic.problems[file_name].first[:column].should be 0 }
-    specify { critic.problems[file_name].first[:level].should be :error }
-    specify { critic.problems[file_name].last[:type].should == 'indentation_spaces' }
-    specify { critic.problems[file_name].last[:line].should be 3 }
-    specify { critic.problems[file_name].last[:column].should be 5 }
-    specify { critic.problems[file_name].last[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 2 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'allow_hard_tabs' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 0 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
+    specify { expect(critic.problems[file_name].last[:type]).to eq 'indentation_spaces' }
+    specify { expect(critic.problems[file_name].last[:line]).to eq 3 }
+    specify { expect(critic.problems[file_name].last[:column]).to eq 5 }
+    specify { expect(critic.problems[file_name].last[:level]).to eq :error }
   end
 end

--- a/spec/functional/horizontal_spacing/long_lines_spec.rb
+++ b/spec/functional/horizontal_spacing/long_lines_spec.rb
@@ -2,16 +2,14 @@ require 'spec_helper'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 LONG_LINE = {}
-LONG_LINE['long_line_no_newline'] = %Q{'#{'#' * 79}'}
-LONG_LINE['long_line_newline_at_82'] = %Q{'#{'#' * 79}'
-}
-
+LONG_LINE['long_line_no_newline'] = %('#{'#' * 79}')
+LONG_LINE['long_line_newline_at_82'] = %('#{'#' * 79}'
+)
 
 describe 'Long line detection' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     File.open(file_name, 'w') { |f| f.write contents }
     critic.check_file(file_name, style.to_hash)
@@ -21,7 +19,7 @@ describe 'Long line detection' do
     Tailor::Critic.new
   end
 
-  let(:contents) { LONG_LINE[file_name]}
+  let(:contents) { LONG_LINE[file_name] }
 
   let(:style) do
     style = Tailor::Configuration::Style.new
@@ -33,19 +31,19 @@ describe 'Long line detection' do
 
   context 'line is 81 chars, no newline' do
     let(:file_name) { 'long_line_no_newline' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'max_line_length' }
-    specify { critic.problems[file_name].first[:line].should be 1 }
-    specify { critic.problems[file_name].first[:column].should be 81 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'max_line_length' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 81 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 
   context 'line is 81 chars, plus a newline' do
     let(:file_name) { 'long_line_newline_at_82' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'max_line_length' }
-    specify { critic.problems[file_name].first[:line].should be 1 }
-    specify { critic.problems[file_name].first[:column].should be 81 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'max_line_length' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 81 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 end

--- a/spec/functional/horizontal_spacing/long_methods_spec.rb
+++ b/spec/functional/horizontal_spacing/long_methods_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 LONG_METHOD_IN_CLASS = {}
 LONG_METHOD_IN_CLASS['ok_with_equals'] = <<-METH
 class Test
@@ -21,7 +20,7 @@ METH
 
 describe 'Long method detection' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     File.open('long_method.rb', 'w') { |f| f.write contents }
     subject.check_file(file_name, style.to_hash)
@@ -46,10 +45,11 @@ describe 'Long method detection' do
   context 'methods are within limits' do
     context 'method ends with line that ends with ==' do
       let(:file_name) { 'ok_with_equals' }
-      specify {
+      specify do
         pending 'https://github.com/turboladen/tailor/issues/112'
 
-        subject.problems[file_name].size.should be 1 }
+        expect(subject.problems[file_name].size).to eq 1
+      end
     end
   end
 end

--- a/spec/functional/horizontal_spacing/parens_spec.rb
+++ b/spec/functional/horizontal_spacing/parens_spec.rb
@@ -2,24 +2,23 @@ require 'spec_helper'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 PARENS = {}
-PARENS['simple_method_call_space_after_lparen'] = %Q{thing( one, two)}
-PARENS['simple_method_call_space_before_rparen'] = %Q{thing(one, two )}
+PARENS['simple_method_call_space_after_lparen'] = %(thing( one, two))
+PARENS['simple_method_call_space_before_rparen'] = %(thing(one, two ))
 PARENS['method_call_space_after_lparen_trailing_comment'] =
-  %Q{thing( one, two)    # comment}
+  %(thing( one, two)    # comment)
 PARENS['method_call_space_after_lparen_before_rparen_trailing_comment'] =
-  %Q{thing( one, two )    # comment}
+  %(thing( one, two )    # comment)
 
-PARENS['multi_line_method_call_space_after_lparen'] = %Q{thing( one,
-  two)}
+PARENS['multi_line_method_call_space_after_lparen'] = %(thing( one,
+  two))
 PARENS['multi_line_method_call_space_after_lparen_trailing_comment'] =
-  %Q{thing( one,
-  two)}
+  %(thing( one,
+  two))
 
 describe 'Detection of spaces around brackets' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     File.open(file_name, 'w') { |f| f.write contents }
     critic.check_file(file_name, style.to_hash)
@@ -29,7 +28,7 @@ describe 'Detection of spaces around brackets' do
     Tailor::Critic.new
   end
 
-  let(:contents) { PARENS[file_name]}
+  let(:contents) { PARENS[file_name] }
 
   let(:style) do
     style = Tailor::Configuration::Style.new
@@ -42,61 +41,62 @@ describe 'Detection of spaces around brackets' do
   context 'methods' do
     context 'space after lparen' do
       let(:file_name) { 'simple_method_call_space_after_lparen' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'spaces_after_lparen' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 6 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_lparen' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 6 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'space before rparen' do
       let(:file_name) { 'simple_method_call_space_before_rparen' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'spaces_before_rparen' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 15 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_before_rparen' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 15 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'space after lparen, trailing comment' do
       let(:file_name) { 'method_call_space_after_lparen_trailing_comment' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'spaces_after_lparen' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 6 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_lparen' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 6 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'space after lparen, before rparen, trailing comment' do
       let(:file_name) { 'method_call_space_after_lparen_before_rparen_trailing_comment' }
-      specify { critic.problems[file_name].size.should be 2 }
-      specify { critic.problems[file_name].first[:type].should == 'spaces_after_lparen' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 6 }
-      specify { critic.problems[file_name].first[:level].should be :error }
-      specify { critic.problems[file_name].last[:type].should == 'spaces_before_rparen' }
-      specify { critic.problems[file_name].last[:line].should be 1 }
-      specify { critic.problems[file_name].last[:column].should be 16 }
-      specify { critic.problems[file_name].last[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_lparen' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 6 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
+      specify { expect(critic.problems[file_name].last[:type]).to eq 'spaces_before_rparen' }
+      specify { expect(critic.problems[file_name].last[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].last[:column]).to eq 16 }
+      specify { expect(critic.problems[file_name].last[:level]).to eq :error }
     end
   end
 
   context 'multi-line method calls' do
     context 'space after lparen' do
       let(:file_name) { 'multi_line_method_call_space_after_lparen' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'spaces_after_lparen' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 6 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_lparen' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 6 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
+
     context 'space after lparen, trailing comment' do
       let(:file_name) { 'multi_line_method_call_space_after_lparen_trailing_comment' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'spaces_after_lparen' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 6 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'spaces_after_lparen' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 6 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 end

--- a/spec/functional/horizontal_spacing/trailing_whitespace_spec.rb
+++ b/spec/functional/horizontal_spacing/trailing_whitespace_spec.rb
@@ -3,21 +3,20 @@ require_relative '../../support/horizontal_spacing_cases'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 TRAILING_WHITESPACE = {}
-TRAILING_WHITESPACE['empty_line_with_spaces'] = %Q{  }
-TRAILING_WHITESPACE['empty_line_with_spaces_in_method'] = %Q{def thing
+TRAILING_WHITESPACE['empty_line_with_spaces'] = %(  )
+TRAILING_WHITESPACE['empty_line_with_spaces_in_method'] = %(def thing
   
   puts 'something'
-end}
+end)
 
-TRAILING_WHITESPACE['trailing_spaces_on_def'] = %Q{def thing  
+TRAILING_WHITESPACE['trailing_spaces_on_def'] = %(def thing  
   puts 'something'
-end}
+end)
 
 describe 'Trailing whitespace detection' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     File.open(file_name, 'w') { |f| f.write contents }
     critic.check_file(file_name, style.to_hash)
@@ -27,7 +26,7 @@ describe 'Trailing whitespace detection' do
     Tailor::Critic.new
   end
 
-  let(:contents) { TRAILING_WHITESPACE[file_name]}
+  let(:contents) { TRAILING_WHITESPACE[file_name] }
 
   let(:style) do
     style = Tailor::Configuration::Style.new

--- a/spec/functional/horizontal_spacing_spec.rb
+++ b/spec/functional/horizontal_spacing_spec.rb
@@ -5,7 +5,7 @@ require 'tailor/configuration/style'
 
 describe 'Horizontal Space problem detection' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
   end
 
@@ -27,9 +27,9 @@ describe 'Horizontal Space problem detection' do
       File.open(file_name, 'w') { |f| f.write contents }
     end
 
-    it 'should be OK' do
+    it 'is OK' do
       critic.check_file(file_name, style.to_hash)
-      critic.problems.should == { file_name =>  [] }
+      expect(critic.problems).to eq(file_name =>  [])
     end
   end
 
@@ -43,31 +43,31 @@ describe 'Horizontal Space problem detection' do
 
     context 'no problems' do
       let(:contents) do
-        %Q{execute 'myscript' do
+        %(execute 'myscript' do
   command \\
     '/some/line/that/is/not/over/eighty/chars.sh'
   only_if { something }
-end}
+end)
       end
 
       it 'is OK' do
         critic.check_file(file_name, style.to_hash)
-        critic.problems.should == { file_name => [] }
+        expect(critic.problems).to eq(file_name => [])
       end
     end
 
     context 'line after backslash is too long' do
       let(:contents) do
-        %Q{execute 'myscript' do
+        %(execute 'myscript' do
   command \\
     '#{'*' * 75}'
   only_if { something }
-end}
+end)
       end
 
       it 'is OK' do
         critic.check_file(file_name, style.to_hash)
-        critic.problems.should == {
+        expect(critic.problems).to eq(
           file_name => [
             {
               type: 'max_line_length',
@@ -76,8 +76,7 @@ end}
               message: 'Line is 81 chars long, but should be 80.',
               level: :error
             }
-          ]
-        }
+          ])
       end
     end
   end

--- a/spec/functional/indentation_spacing/argument_alignment_spec.rb
+++ b/spec/functional/indentation_spacing/argument_alignment_spec.rb
@@ -4,19 +4,18 @@ require 'tailor/critic'
 require 'tailor/configuration/style'
 
 describe 'Argument alignment' do
-
   def file_name
     self.class.description
   end
 
   def contents
     ARG_INDENT[file_name] || begin
-      raise "Example not found: #{file_name}"
+      fail "Example not found: #{file_name}"
     end
   end
 
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     FileUtils.touch file_name
     File.open(file_name, 'w') { |f| f.write contents }
@@ -32,7 +31,6 @@ describe 'Argument alignment' do
   end
 
   context :def_no_arguments do
-
     it 'does not warn when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
@@ -49,11 +47,9 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :def_arguments_fit_on_one_line do
-
     it 'does not warn when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
@@ -70,18 +66,16 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :def_arguments_aligned do
-
     it 'warns when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to eql [{
         type: 'indentation_spaces',
         line: 2,
         column: 14,
-        message: "Line is indented to column 14, but should be at 2.",
+        message: 'Line is indented to column 14, but should be at 2.',
         level: :error
       }]
     end
@@ -93,7 +87,7 @@ describe 'Argument alignment' do
         type: 'indentation_spaces',
         line: 2,
         column: 14,
-        message: "Line is indented to column 14, but should be at 2.",
+        message: 'Line is indented to column 14, but should be at 2.',
         level: :error
       }]
     end
@@ -103,11 +97,9 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :def_arguments_indented do
-
     it 'does not warn when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
@@ -126,15 +118,13 @@ describe 'Argument alignment' do
         type: 'indentation_spaces',
         line: 2,
         column: 2,
-        message: "Line is indented to column 2, but should be at 14.",
+        message: 'Line is indented to column 2, but should be at 14.',
         level: :error
       }]
     end
-
   end
 
   context :call_arguments_fit_on_one_line do
-
     it 'does not warn when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
@@ -151,11 +141,9 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :call_no_arguments do
-
     it 'does not warn when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
@@ -172,18 +160,16 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :call_arguments_aligned do
-
     it 'warns when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to eql [{
         type: 'indentation_spaces',
         line: 2,
         column: 49,
-        message: "Line is indented to column 49, but should be at 2.",
+        message: 'Line is indented to column 49, but should be at 2.',
         level: :error
       }]
     end
@@ -195,7 +181,7 @@ describe 'Argument alignment' do
         type: 'indentation_spaces',
         line: 2,
         column: 49,
-        message: "Line is indented to column 49, but should be at 2.",
+        message: 'Line is indented to column 49, but should be at 2.',
         level: :error
       }]
     end
@@ -205,18 +191,16 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :call_arguments_aligned_args_are_integer_literals do
-
     it 'warns when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to eql [{
         type: 'indentation_spaces',
         line: 2,
         column: 49,
-        message: "Line is indented to column 49, but should be at 2.",
+        message: 'Line is indented to column 49, but should be at 2.',
         level: :error
       }]
     end
@@ -228,7 +212,7 @@ describe 'Argument alignment' do
         type: 'indentation_spaces',
         line: 2,
         column: 49,
-        message: "Line is indented to column 49, but should be at 2.",
+        message: 'Line is indented to column 49, but should be at 2.',
         level: :error
       }]
     end
@@ -238,18 +222,16 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :call_arguments_aligned_args_are_string_literals do
-
     it 'warns when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to eql [{
         type: 'indentation_spaces',
         line: 2,
         column: 49,
-        message: "Line is indented to column 49, but should be at 2.",
+        message: 'Line is indented to column 49, but should be at 2.',
         level: :error
       }]
     end
@@ -261,7 +243,7 @@ describe 'Argument alignment' do
         type: 'indentation_spaces',
         line: 2,
         column: 49,
-        message: "Line is indented to column 49, but should be at 2.",
+        message: 'Line is indented to column 49, but should be at 2.',
         level: :error
       }]
     end
@@ -271,11 +253,9 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :call_arguments_aligned_multiple_lines do
-
     it 'warns when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to eql [
@@ -283,14 +263,14 @@ describe 'Argument alignment' do
           type: 'indentation_spaces',
           line: 2,
           column: 49,
-          message: "Line is indented to column 49, but should be at 2.",
+          message: 'Line is indented to column 49, but should be at 2.',
           level: :error
         },
         {
           type: 'indentation_spaces',
           line: 3,
           column: 49,
-          message: "Line is indented to column 49, but should be at 2.",
+          message: 'Line is indented to column 49, but should be at 2.',
           level: :error
         }
       ]
@@ -304,14 +284,14 @@ describe 'Argument alignment' do
           type: 'indentation_spaces',
           line: 2,
           column: 49,
-          message: "Line is indented to column 49, but should be at 2.",
+          message: 'Line is indented to column 49, but should be at 2.',
           level: :error
         },
         {
           type: 'indentation_spaces',
           line: 3,
           column: 49,
-          message: "Line is indented to column 49, but should be at 2.",
+          message: 'Line is indented to column 49, but should be at 2.',
           level: :error
         }
       ]
@@ -322,7 +302,6 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :call_arguments_aligned_args_have_parens do
@@ -333,7 +312,7 @@ describe 'Argument alignment' do
           type: 'indentation_spaces',
           line: 2,
           column: 49,
-          message: "Line is indented to column 49, but should be at 2.",
+          message: 'Line is indented to column 49, but should be at 2.',
           level: :error
         }
       ]
@@ -347,7 +326,7 @@ describe 'Argument alignment' do
           type: 'indentation_spaces',
           line: 2,
           column: 49,
-          message: "Line is indented to column 49, but should be at 2.",
+          message: 'Line is indented to column 49, but should be at 2.',
           level: :error
         }
       ]
@@ -358,19 +337,16 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
-
   end
 
   context :call_arguments_aligned_no_parens do
-
     it 'warns when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to eql [{
         type: 'indentation_spaces',
         line: 2,
         column: 49,
-        message: "Line is indented to column 49, but should be at 2.",
+        message: 'Line is indented to column 49, but should be at 2.',
         level: :error
       }]
     end
@@ -382,7 +358,7 @@ describe 'Argument alignment' do
         type: 'indentation_spaces',
         line: 2,
         column: 49,
-        message: "Line is indented to column 49, but should be at 2.",
+        message: 'Line is indented to column 49, but should be at 2.',
         level: :error
       }]
     end
@@ -392,11 +368,9 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :call_arguments_indented do
-
     it 'does not warn when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
@@ -415,15 +389,13 @@ describe 'Argument alignment' do
         type: 'indentation_spaces',
         line: 2,
         column: 2,
-        message: "Line is indented to column 2, but should be at 49.",
+        message: 'Line is indented to column 2, but should be at 49.',
         level: :error
       }]
     end
-
   end
 
   context :call_arguments_indented_separate_line do
-
     it 'does not warn when argument alignment is not specified' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
@@ -440,11 +412,9 @@ describe 'Argument alignment' do
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :call_arguments_on_next_line do
-
     it 'does not warn when argument alignment is not specified' do
       style.indentation_spaces 2, level: :error, line_continuations: true
       critic.check_file(file_name, style.to_hash)
@@ -452,21 +422,21 @@ describe 'Argument alignment' do
     end
 
     it 'does not warn when argument alignment is disabled' do
-      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: :off
+      style.indentation_spaces 2, level: :error, line_continuations: true,
+        argument_alignment: :off
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
 
     it 'does not warn when argument alignment is enabled' do
-      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: true
+      style.indentation_spaces 2, level: :error, line_continuations: true,
+        argument_alignment: true
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
 
   context :call_arguments_on_next_line_nested do
-
     it 'does not warn when argument alignment is not specified' do
       style.indentation_spaces 2, level: :error, line_continuations: true
       critic.check_file(file_name, style.to_hash)
@@ -474,20 +444,21 @@ describe 'Argument alignment' do
     end
 
     it 'does not warn when argument alignment is disabled' do
-      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: :off
+      style.indentation_spaces 2, level: :error, line_continuations: true,
+        argument_alignment: :off
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
 
     it 'does not warn when argument alignment is enabled' do
-      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: true
+      style.indentation_spaces 2, level: :error, line_continuations: true,
+        argument_alignment: true
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
+
   context :call_arguments_on_next_line_multiple do
-
     it 'does not warn when argument alignment is not specified' do
       style.indentation_spaces 2, level: :error, line_continuations: true
       critic.check_file(file_name, style.to_hash)
@@ -495,17 +466,17 @@ describe 'Argument alignment' do
     end
 
     it 'does not warn when argument alignment is disabled' do
-      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: :off
+      style.indentation_spaces 2, level: :error, line_continuations: true,
+        argument_alignment: :off
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
 
     it 'does not warn when argument alignment is enabled' do
-      style.indentation_spaces 2, level: :error, line_continuations: true, argument_alignment: true
+      style.indentation_spaces 2, level: :error, line_continuations: true,
+        argument_alignment: true
       critic.check_file(file_name, style.to_hash)
       expect(critic.problems[file_name]).to be_empty
     end
-
   end
-
 end

--- a/spec/functional/indentation_spacing/bad_indentation_spec.rb
+++ b/spec/functional/indentation_spacing/bad_indentation_spec.rb
@@ -3,7 +3,6 @@ require_relative '../../support/bad_indentation_cases'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 describe 'Detection of method length' do
   before do
     Tailor::Logger.stub(:log)
@@ -29,339 +28,337 @@ describe 'Detection of method length' do
   context 'simple classes' do
     context 'empty with an indented end' do
       let(:file_name) { 'class_indented_end' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'body extra indented' do
       let(:file_name) { 'class_indented_single_statement' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'body extra indented, trailing comment' do
       let(:file_name) { 'class_indented_single_statement_trailing_comment' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'body extra outdented' do
       let(:file_name) { 'class_outdented_single_statement' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
   context 'simple methods' do
     context 'empty with an indented end' do
       let(:file_name) { 'def_indented_end' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'body and end extra indented' do
       let(:file_name) { 'def_content_indented_end' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 3 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'in a class, end outdented' do
       let(:file_name) { 'class_def_content_outdented_end' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 4 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 4 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'in a class, body outdented' do
       let(:file_name) { 'class_def_outdented_content' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 3 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'class method outdented, in a class' do
       let(:file_name) { 'class_method_def_using_self_outdented' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
   context 'case statements' do
     context 'case extra indented' do
       let(:file_name) { 'case_indented_whens_level' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'case extra indented, trailing comment' do
       let(:file_name) { 'case_indented_whens_level_trailing_comment' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'case extra outdented' do
       let(:file_name) { 'case_outdented_whens_level' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'when extra intdented' do
       let(:file_name) { 'case_when_indented_whens_level' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 3 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'when extra outdented' do
       let(:file_name) { 'case_when_outdented_whens_level' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 3 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'case extra indented' do
       pending 'Implementation of option to allow whens in'
 
-=begin
-      let(:file_name) { 'case_indented_whens_in' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
-=end
+      # let(:file_name) { 'case_indented_whens_in' }
+      # specify { expect(critic.problems[file_name].size).to eq 1 }
+      # specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      # specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      # specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      # specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
   context 'while/do loops' do
     context 'while/do indented' do
       let(:file_name) { 'while_do_indented' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'while/do outdented' do
       let(:file_name) { 'while_do_outdented' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'while/do content outdented' do
       let(:file_name) { 'while_do_content_outdented' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 3 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'while/do content indented' do
       let(:file_name) { 'while_do_content_indented' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 3 }
-      specify { critic.problems[file_name].first[:column].should be 5 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 5 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'another while/do indented' do
       let(:file_name) { 'while_do_indented2' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 4 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 4 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'another while/do indented, trailing comment' do
       let(:file_name) { 'while_do_indented2_trailing_comment' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 4 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 4 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
   context 'until/do loops' do
     context 'until indented' do
       let(:file_name) { 'until_do_indented' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 4 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 4 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
   context 'for/do loops' do
     context 'for indented' do
       let(:file_name) { 'for_do_indented' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
   context 'loop/do loops' do
     context 'loop indented' do
       let(:file_name) { 'loop_do_indented' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 1 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
   context 'if statements' do
     context 'first line extra indented' do
       let(:file_name) { 'if_line_indented' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'first line extra indented, trailing comment' do
       let(:file_name) { 'if_line_indented_trailing_comment' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
   context 'multi_line_tstring' do
     let(:file_name) { 'multi_line_tstring' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-    specify { critic.problems[file_name].first[:line].should be 2 }
-    specify { critic.problems[file_name].first[:column].should be 0 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 0 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 
   context 'operators' do
     context 'multi-line &&, first line indented' do
       let(:file_name) { 'multi_line_andop_first_line_indented' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'multi-line &&, first line indented, trailing comment' do
       let(:file_name) { 'multi_line_andop_first_line_indented_trailing_comment' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'multi-line &&, second line indented' do
       let(:file_name) { 'multi_line_andop_second_line_indented' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 3 }
-      specify { critic.problems[file_name].first[:column].should be 5 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 5 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'multi-line string concat, second line outdented' do
       let(:file_name) { 'multi_line_string_concat_with_plus_out' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 2 }
-      specify { critic.problems[file_name].first[:column].should be 1 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 2 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 
   context 'combinations of stuff' do
     context 'multi-line if with end in' do
       let(:file_name) { 'multi_line_method_call_end_in' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 5 }
-      specify { critic.problems[file_name].first[:column].should be 3 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 5 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'multi-line chained methods with 2nd line in' do
       let(:file_name) { 'multi_line_method_call_ends_with_period_2nd_line_in' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 4 }
-      specify { critic.problems[file_name].first[:column].should be 5 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 4 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 5 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'multi-line chained methods with 3rd line in' do
       let(:file_name) { 'multi_line_method_call_ends_with_many_periods_last_in' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 3 }
-      specify { critic.problems[file_name].first[:column].should be 4 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 4 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
 
     context 'multi-line chained methods with 3rd line in, trailing comment' do
       let(:file_name) { 'multi_line_method_call_ends_with_many_periods_last_in_trailing_comment' }
-      specify { critic.problems[file_name].size.should be 1 }
-      specify { critic.problems[file_name].first[:type].should == 'indentation_spaces' }
-      specify { critic.problems[file_name].first[:line].should be 3 }
-      specify { critic.problems[file_name].first[:column].should be 4 }
-      specify { critic.problems[file_name].first[:level].should be :error }
+      specify { expect(critic.problems[file_name].size).to eq 1 }
+      specify { expect(critic.problems[file_name].first[:type]).to eq 'indentation_spaces' }
+      specify { expect(critic.problems[file_name].first[:line]).to eq 3 }
+      specify { expect(critic.problems[file_name].first[:column]).to eq 4 }
+      specify { expect(critic.problems[file_name].first[:level]).to eq :error }
     end
   end
 end

--- a/spec/functional/indentation_spacing_spec.rb
+++ b/spec/functional/indentation_spacing_spec.rb
@@ -3,10 +3,9 @@ require_relative '../support/good_indentation_cases'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 describe 'Indentation spacing problem detection' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
   end
 
@@ -30,9 +29,9 @@ describe 'Indentation spacing problem detection' do
       File.open(file_name, 'w') { |f| f.write contents }
     end
 
-    it 'should be OK' do
+    it 'is OK' do
       critic.check_file(file_name, style.to_hash)
-      critic.problems.should == { file_name =>  [] }
+      expect(critic.problems).to eq(file_name =>  [])
     end
   end
 
@@ -40,18 +39,18 @@ describe 'Indentation spacing problem detection' do
     let(:file_name) { 'case_whens_in' }
 
     let(:contents) do
-      %Q{def my_method
+      %(def my_method
   case true
     when true
       puts "stuff"
     when false
       puts "blah blah"
   end
-end}
+end)
     end
 
     it 'is OK' do
-      pending 'Implementation of the option to allow for this'
+      skip 'Implementation of the option to allow for this'
     end
   end
 
@@ -59,13 +58,13 @@ end}
     let(:file_name) { 'method_closing_lonely_paren' }
 
     let(:contents) do
-      %Q{def your_thing(one
+      %{def your_thing(one
   )
 end}
     end
 
     it 'is OK' do
-      pending
+      skip 'Implementation'
     end
   end
 
@@ -73,14 +72,14 @@ end}
     let(:file_name) { 'rparen_and_do_same_line' }
 
     let(:contents) do
-      %Q{opt.on('-c', '--config-file FILE',
+      %{opt.on('-c', '--config-file FILE',
   "Use a specific config file.") do |config|
   options.config_file = config
 end}
     end
 
     it 'is OK' do
-      pending
+      skip 'Implementation'
     end
   end
 
@@ -88,16 +87,16 @@ end}
     let(:file_name) { 'block_chain' }
 
     let(:contents) do
-      %Q{{
+      %({
   a: 1
 }.each do |k, v|
   puts k, v
-end}
+end)
     end
 
     it 'is OK' do
       critic.check_file(file_name, style.to_hash)
-      critic.problems.should == { file_name =>  [] }
+      expect(critic.problems).to eq(file_name =>  [])
     end
   end
 end

--- a/spec/functional/naming/camel_case_methods_spec.rb
+++ b/spec/functional/naming/camel_case_methods_spec.rb
@@ -2,17 +2,15 @@ require 'spec_helper'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 CAMEL_CASE_METHODS = {}
 
 CAMEL_CASE_METHODS['one_caps_camel_case_method'] =
-  %Q{def thingOne
-end}
+  %(def thingOne
+end)
 
 CAMEL_CASE_METHODS['one_caps_camel_case_method_trailing_comment'] =
-  %Q{def thingOne   # comment
-end}
-
+  %(def thingOne   # comment
+end)
 
 describe 'Detection of camel case methods' do
   before do

--- a/spec/functional/naming/screaming_snake_case_classes_spec.rb
+++ b/spec/functional/naming/screaming_snake_case_classes_spec.rb
@@ -2,26 +2,23 @@ require 'spec_helper'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 SCREAMING_SNAKE_CASE_CLASSES = {}
 
 SCREAMING_SNAKE_CASE_CLASSES['one_screaming_snake_case_class'] =
-  %Q{class Thing_One
-end}
+  %(class Thing_One
+end)
 
 SCREAMING_SNAKE_CASE_CLASSES['one_screaming_snake_case_module'] =
-  %Q{module Thing_One
-end}
+  %(module Thing_One
+end)
 
 SCREAMING_SNAKE_CASE_CLASSES['double_screaming_snake_case_class'] =
-  %Q{class Thing_One_Again
-end}
+  %(class Thing_One_Again
+end)
 
 SCREAMING_SNAKE_CASE_CLASSES['double_screaming_snake_case_module'] =
-  %Q{module Thing_One_Again
-end}
-
-
+  %(module Thing_One_Again
+end)
 
 describe 'Detection of camel case methods' do
   before do
@@ -47,37 +44,37 @@ describe 'Detection of camel case methods' do
 
   context 'standard screaming snake case class' do
     let(:file_name) { 'one_screaming_snake_case_class' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'allow_screaming_snake_case_classes' }
-    specify { critic.problems[file_name].first[:line].should be 1 }
-    specify { critic.problems[file_name].first[:column].should be 6 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'allow_screaming_snake_case_classes' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 6 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 
   context 'standard screaming snake case module' do
     let(:file_name) { 'one_screaming_snake_case_module' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'allow_screaming_snake_case_classes' }
-    specify { critic.problems[file_name].first[:line].should be 1 }
-    specify { critic.problems[file_name].first[:column].should be 7 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'allow_screaming_snake_case_classes' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 7 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 
   context 'double screaming snake case class' do
     let(:file_name) { 'double_screaming_snake_case_class' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'allow_screaming_snake_case_classes' }
-    specify { critic.problems[file_name].first[:line].should be 1 }
-    specify { critic.problems[file_name].first[:column].should be 6 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'allow_screaming_snake_case_classes' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 6 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 
   context 'double screaming snake case module' do
     let(:file_name) { 'double_screaming_snake_case_module' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'allow_screaming_snake_case_classes' }
-    specify { critic.problems[file_name].first[:line].should be 1 }
-    specify { critic.problems[file_name].first[:column].should be 7 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'allow_screaming_snake_case_classes' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 7 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 end

--- a/spec/functional/naming_spec.rb
+++ b/spec/functional/naming_spec.rb
@@ -6,7 +6,7 @@ require 'tailor/configuration/style'
 
 describe 'Naming problem detection' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
   end
 
@@ -28,9 +28,9 @@ describe 'Naming problem detection' do
       File.open(file_name, 'w') { |f| f.write contents }
     end
 
-    it 'should be OK' do
+    it 'is OK' do
       critic.check_file(file_name, style.to_hash)
-      critic.problems.should == { file_name =>  [] }
+      expect(critic.problems).to eq(file_name =>  [])
     end
   end
 end

--- a/spec/functional/rake_task_spec.rb
+++ b/spec/functional/rake_task_spec.rb
@@ -60,7 +60,7 @@ describe Tailor::RakeTask do
 
       expect {
         rake[task_name].invoke
-      }.to_not raise_error RuntimeError, "Don't know how to build task '#{task_name}''"
+      }.to raise_exception SystemExit
     end
   end
 
@@ -93,7 +93,7 @@ describe Tailor::RakeTask do
         FileUtils.mkdir(test_dir)
       end
 
-      File.directory?(test_dir).should be_true
+      expect(File.directory?(test_dir)).to eq true
 
       File.open(test_dir + '/test.rb', 'w') do |f|
         f.write <<-CONTENTS
@@ -101,7 +101,7 @@ puts 'I no have end quote
         CONTENTS
       end
 
-      File.exists?(test_dir + '/test.rb').should be_true
+      expect(File.exists?(test_dir + '/test.rb')).to eq true
     end
 
     after do

--- a/spec/functional/rake_task_spec.rb
+++ b/spec/functional/rake_task_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'tailor/rake_task'
 
-
 describe Tailor::RakeTask do
   let(:rake) do
     Rake::Application.new
@@ -22,10 +21,7 @@ describe Tailor::RakeTask do
 
       it 'finds problems' do
         subject
-
-        expect {
-          rake['tailor'].invoke
-        }.to raise_error SystemExit
+        expect { rake['tailor'].invoke }.to raise_error SystemExit
       end
     end
 
@@ -38,10 +34,7 @@ describe Tailor::RakeTask do
 
       it 'does not find problems' do
         subject
-
-        expect {
-          rake['tailor'].invoke
-        }.to_not raise_error
+        expect { rake['tailor'].invoke }.to_not raise_error
       end
     end
   end
@@ -57,10 +50,7 @@ describe Tailor::RakeTask do
 
     it 'runs the task' do
       subject
-
-      expect {
-        rake[task_name].invoke
-      }.to raise_exception SystemExit
+      expect { rake[task_name].invoke }.to raise_exception SystemExit
     end
   end
 
@@ -68,16 +58,13 @@ describe Tailor::RakeTask do
     subject do
       Tailor::RakeTask.new do |t|
         t.config_file = File.expand_path 'spec/support/rake_task_config_problems.rb'
-        t.tailor_opts = %w[--max-line-length=1000]
+        t.tailor_opts = %w(--max-line-length=1000)
       end
     end
 
     it 'uses the options from the rake task' do
       subject
-
-      expect {
-        rake['tailor'].invoke
-      }.to_not raise_error
+      expect { rake['tailor'].invoke }.to_not raise_error
     end
   end
 
@@ -89,10 +76,7 @@ describe Tailor::RakeTask do
     before do
       require 'fileutils'
 
-      unless File.exists?(test_dir)
-        FileUtils.mkdir(test_dir)
-      end
-
+      FileUtils.mkdir(test_dir)  unless File.exist?(test_dir)
       expect(File.directory?(test_dir)).to eq true
 
       File.open(test_dir + '/test.rb', 'w') do |f|
@@ -101,7 +85,7 @@ puts 'I no have end quote
         CONTENTS
       end
 
-      expect(File.exists?(test_dir + '/test.rb')).to eq true
+      expect(File.exist?(test_dir + '/test.rb')).to eq true
     end
 
     after do
@@ -120,10 +104,7 @@ puts 'I no have end quote
 
     it 'uses the options from the rake task' do
       subject
-
-      expect {
-        rake['tailor'].invoke
-      }.to raise_error
+      expect { rake['tailor'].invoke }.to raise_error
     end
   end
 end

--- a/spec/functional/string_interpolation_spec.rb
+++ b/spec/functional/string_interpolation_spec.rb
@@ -15,7 +15,7 @@ describe 'String interpolation cases' do
   end
 
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     FileUtils.touch file_name
     File.open(file_name, 'w') { |f| f.write contents }

--- a/spec/functional/string_quoting_spec.rb
+++ b/spec/functional/string_quoting_spec.rb
@@ -16,7 +16,7 @@ describe 'String Quoting' do
   end
 
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     FileUtils.touch file_name
     File.open(file_name, 'w') { |f| f.write contents }

--- a/spec/functional/vertical_spacing/class_length_spec.rb
+++ b/spec/functional/vertical_spacing/class_length_spec.rb
@@ -2,27 +2,25 @@ require 'spec_helper'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 CLASS_LENGTH = {}
 CLASS_LENGTH['class_too_long'] =
-  %Q{class Party
+  %(class Party
   include Clowns
   include Pizza
 
   def barrel_roll
     puts 'DOABARRELROLL!'
   end
-end}
+end)
 
 CLASS_LENGTH['parent_class_too_long'] =
-  %Q{class Party
+  %(class Party
 
   class Pizza
     include Cheese
     include Yumminess
   end
-end}
-
+end)
 
 describe 'Detection of class length' do
   before do

--- a/spec/functional/vertical_spacing/method_length_spec.rb
+++ b/spec/functional/vertical_spacing/method_length_spec.rb
@@ -2,25 +2,23 @@ require 'spec_helper'
 require 'tailor/critic'
 require 'tailor/configuration/style'
 
-
 METHOD_LENGTH = {}
 METHOD_LENGTH['method_too_long'] =
-  %Q{def thing
+  %(def thing
   puts
   puts
-end}
+end)
 
 METHOD_LENGTH['parent_method_too_long'] =
-  %Q{def thing
+  %(def thing
   puts
   def inner_thing; print '1'; end
   puts
-end}
-
+end)
 
 describe 'Detection of method length' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
     File.open(file_name, 'w') { |f| f.write contents }
     critic.check_file(file_name, style.to_hash)
@@ -43,19 +41,19 @@ describe 'Detection of method length' do
 
   context 'single class too long' do
     let(:file_name) { 'method_too_long' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'max_code_lines_in_method' }
-    specify { critic.problems[file_name].first[:line].should be 1 }
-    specify { critic.problems[file_name].first[:column].should be 0 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'max_code_lines_in_method' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 0 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 
   context 'method in a method' do
     let(:file_name) { 'method_too_long' }
-    specify { critic.problems[file_name].size.should be 1 }
-    specify { critic.problems[file_name].first[:type].should == 'max_code_lines_in_method' }
-    specify { critic.problems[file_name].first[:line].should be 1 }
-    specify { critic.problems[file_name].first[:column].should be 0 }
-    specify { critic.problems[file_name].first[:level].should be :error }
+    specify { expect(critic.problems[file_name].size).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:type]).to eq 'max_code_lines_in_method' }
+    specify { expect(critic.problems[file_name].first[:line]).to eq 1 }
+    specify { expect(critic.problems[file_name].first[:column]).to eq 0 }
+    specify { expect(critic.problems[file_name].first[:level]).to eq :error }
   end
 end

--- a/spec/functional/vertical_spacing_spec.rb
+++ b/spec/functional/vertical_spacing_spec.rb
@@ -6,7 +6,7 @@ require 'tailor/configuration/style'
 
 describe 'Vertical Space problem detection' do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     FakeFS.activate!
   end
 
@@ -28,9 +28,9 @@ describe 'Vertical Space problem detection' do
       File.open(file_name, 'w') { |f| f.write contents }
     end
 
-    it 'should be OK' do
+    it 'is OK' do
       critic.check_file(file_name, style.to_hash)
-      critic.problems.should == { file_name =>  [] }
+      expect(critic.problems).to eq(file_name =>  [])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 require 'fakefs/spec_helpers'
+require 'rspec/its'
 require 'simplecov'
 
 SimpleCov.start
+
 
 RSpec.configure do |config|
   config.include FakeFS::SpecHelpers

--- a/spec/support/argument_alignment_cases.rb
+++ b/spec/support/argument_alignment_cases.rb
@@ -1,93 +1,93 @@
 ARG_INDENT = {}
 
 ARG_INDENT['def_no_arguments'] =
-  %q{def foo
+  %(def foo
   true
-end}
+end)
 
 ARG_INDENT['def_arguments_fit_on_one_line'] =
-  %q{def foo(foo, bar, baz)
+  %(def foo(foo, bar, baz)
   true
-end}
+end)
 
 ARG_INDENT['def_arguments_aligned'] =
-  %q{def something(waka, baka, bing,
+  %(def something(waka, baka, bing,
               bla, goop, foop)
   stuff
 end
-}
+)
 
 ARG_INDENT['def_arguments_indented'] =
-  %q{def something(waka, baka, bing,
+  %(def something(waka, baka, bing,
   bla, goop, foop)
   stuff
 end
-}
+)
 
 ARG_INDENT['call_no_arguments'] =
-  %q{bla = method()}
+  %(bla = method())
 
 ARG_INDENT['call_arguments_fit_on_one_line'] =
-  %q{bla = method(foo, bar, baz, bing, ding)}
+  %(bla = method(foo, bar, baz, bing, ding))
 
 ARG_INDENT['call_arguments_aligned'] =
-  %q{bla = Something::SomethingElse::SomeClass.method(foo, bar, baz,
+  %(bla = Something::SomethingElse::SomeClass.method(foo, bar, baz,
                                                  bing, ding)
-}
+)
 
 ARG_INDENT['call_arguments_aligned_args_are_integer_literals'] =
-  %q{bla = Something::SomethingElse::SomeClass.method(1, 2, 3,
+  %(bla = Something::SomethingElse::SomeClass.method(1, 2, 3,
                                                  4, 5)
-}
+)
 
 ARG_INDENT['call_arguments_aligned_args_are_string_literals'] =
-  %q{bla = Something::SomethingElse::SomeClass.method('foo', 'bar', 'baz',
+  %(bla = Something::SomethingElse::SomeClass.method('foo', 'bar', 'baz',
                                                  'bing', 'ding')
-}
+)
 
 ARG_INDENT['call_arguments_aligned_args_have_parens'] =
-  %q{bla = Something::SomethingElse::SomeClass.method(foo, bar(), baz,
+  %(bla = Something::SomethingElse::SomeClass.method(foo, bar(), baz,
                                                  bing, ding)
-}
+)
 
 ARG_INDENT['call_arguments_aligned_no_parens'] =
-  %q{bla = Something::SomethingElse::SomeClass.method foo, bar, baz,
+  %(bla = Something::SomethingElse::SomeClass.method foo, bar, baz,
                                                  bing, ding
-}
+)
 
 ARG_INDENT['call_arguments_aligned_multiple_lines'] =
-  %q{bla = Something::SomethingElse::SomeClass.method(foo, bar, baz,
+  %(bla = Something::SomethingElse::SomeClass.method(foo, bar, baz,
                                                  bing, ding,
                                                  ginb, gind)
-}
+)
 
 ARG_INDENT['call_arguments_indented'] =
-  %q{bla = Something::SomethingElse::SomeClass.method(foo, bar, baz,
+  %(bla = Something::SomethingElse::SomeClass.method(foo, bar, baz,
   bing, ding)
-}
+)
 
 ARG_INDENT['call_arguments_indented_separate_line'] =
-  %q{bla = Something::SomethingElse::SomeClass.method(
+  %(bla = Something::SomethingElse::SomeClass.method(
   foo, bar, baz,
   bing, ding
-)}
+))
 
 ARG_INDENT['call_arguments_on_next_line'] =
-  %q{some_long_method_that_goes_out_to_the_end_of_the_line(
+  %(some_long_method_that_goes_out_to_the_end_of_the_line(
   foo, bar)
-}
+)
 
 ARG_INDENT['call_arguments_on_next_line_nested'] =
-  %q{if some_long_method_that_goes_out_to_the_end_of_the_line(
+  %(if some_long_method_that_goes_out_to_the_end_of_the_line(
     foo, bar)
   my_nested_expression
-end}
+end)
 
 ARG_INDENT['call_arguments_on_next_line_multiple'] =
-  %q{some_long_method_that_goes_out_to_the_end_of_the_line(
+  %(some_long_method_that_goes_out_to_the_end_of_the_line(
   foo, bar)
 
 if diff_long_method_that_goes_out_to_the_end_of_the_line(
     foo, bar)
   my_nested_expression
-end}
+end)

--- a/spec/support/conditional_parentheses_cases.rb
+++ b/spec/support/conditional_parentheses_cases.rb
@@ -1,60 +1,60 @@
 CONDITIONAL_PARENTHESES = {}
 
 CONDITIONAL_PARENTHESES['no_parentheses'] =
-  %q{if foo
-end}
+  %(if foo
+end)
 
 CONDITIONAL_PARENTHESES['with_parentheses'] =
-  %q{if (foo)
-end}
+  %(if (foo)
+end)
 
 CONDITIONAL_PARENTHESES['with_parentheses_no_space'] =
-  %q{if(foo)
-end}
+  %(if(foo)
+end)
 
 CONDITIONAL_PARENTHESES['method_call'] =
-  %q{if foo(bar)
-end}
+  %(if foo(bar)
+end)
 
 CONDITIONAL_PARENTHESES['indented_method_call'] =
-%q{foo do
+%(foo do
   if foo(bar)
   end
-end}
+end)
 
 CONDITIONAL_PARENTHESES['method_call_on_parens'] =
-  %q{unless (foo & bar).sort
+  %(unless (foo & bar).sort
 end
-}
+)
 
 CONDITIONAL_PARENTHESES['double_parens'] =
-  %q{if ((bar))
-end}
+  %(if ((bar))
+end)
 
 CONDITIONAL_PARENTHESES['unless_no_parentheses'] =
-  %q{unless bar
-end}
+  %(unless bar
+end)
 
 CONDITIONAL_PARENTHESES['unless_with_parentheses'] =
-  %q{unless (bar)
-end}
+  %(unless (bar)
+end)
 
 CONDITIONAL_PARENTHESES['case_no_parentheses'] =
-  %q{case bar
+  %(case bar
 when 1 then 'a'
 when 2 then 'b'
-end}
+end)
 
 CONDITIONAL_PARENTHESES['case_with_parentheses'] =
-  %q{case (bar)
+  %(case (bar)
 when 1 then 'a'
 when 2 then 'b'
-end}
+end)
 
 CONDITIONAL_PARENTHESES['while_no_parentheses'] =
-  %q{while bar
-end}
+  %(while bar
+end)
 
 CONDITIONAL_PARENTHESES['while_with_parentheses'] =
-  %q{while (bar)
-end}
+  %(while (bar)
+end)

--- a/spec/support/good_indentation_cases.rb
+++ b/spec/support/good_indentation_cases.rb
@@ -1,84 +1,84 @@
 INDENT_OK = {}
 
 INDENT_OK['class'] =
-  %Q{class MyClass
-end}
+  %(class MyClass
+end)
 
 INDENT_OK['one_line_class'] =
-  %Q{class MyClass; end}
+  %(class MyClass; end)
 
 INDENT_OK['one_line_subclass'] =
-  %Q{class MyClass < RuntimeError; end}
+  %(class MyClass < RuntimeError; end)
 
 INDENT_OK['one_line_subclass_with_inheritance'] =
-  %Q{class MyClass < Array
+  %(class MyClass < Array
   class MyError < RuntimeError; end
   include AnotherThing
-end}
+end)
 
 INDENT_OK['class_empty'] =
-  %Q{class MyClass
+  %(class MyClass
 
-end}
+end)
 
 INDENT_OK['class_empty_trailing_comment'] =
-  %Q{class MyClass    # Comment!
+  %(class MyClass    # Comment!
 
-end}
+end)
 
 INDENT_OK['class_singlestatement'] =
-  %Q{class MyClass
+  %(class MyClass
   include Stuff
-end}
+end)
 
 INDENT_OK['assignment_addition_multistatement'] =
-  %Q{thing = 1 +
+  %(thing = 1 +
   2 + 3 + 4 +
-  5}
+  5)
 
 INDENT_OK['assignment_addition_multistatement_trailing_comment'] =
-  %Q{thing = 1 +    # Comment!
+  %(thing = 1 +    # Comment!
   2 + 3 + 4 +
-  5}
+  5)
 
 INDENT_OK['assignment_hash_multistatement'] =
-  %Q{thing = {
+  %(thing = {
   :one => 'one',
   two: 'two'
-}}
+})
 
 INDENT_OK['assignment_hash_multistatement_trailing_comment'] =
-  %Q{thing = {
+  %(thing = {
   :one => 'one', # Comment
   two: 'two'
-}}
+})
 
 INDENT_OK['assignment_array_multistatement'] =
-  %Q{thing = [
+  %(thing = [
   :one,
   :two
-]}
+])
 
 INDENT_OK['assignment_array_multistatement_trailing_comment'] =
-  %Q{thing = [
+  %(thing = [
   :one,            # comment
   :two
-]}
+])
 
 INDENT_OK['assignment_paren_multistatement'] =
-  %Q{eval('puts',
+  %(eval('puts',
   binding,
   'my_file.rb',
-  5)}
+  5))
 
 INDENT_OK['assignment_paren_multistatement_trailing_comment'] =
-  %Q{eval('puts',
+  %(eval('puts',
   binding,
   'my_file.rb',         # comment
-  5)}
+  5))
 
 INDENT_OK['assignment_twolevel_hash_multistatement'] =
-  %Q{thing = {
+  %(thing = {
   :one => {
     :a => 'a',
     b: 'b'
@@ -87,56 +87,56 @@ INDENT_OK['assignment_twolevel_hash_multistatement'] =
     x: 'x',
     :y => 'y'
   }
-}}
+})
 
 INDENT_OK['assignment_twolevel_array_multistatement'] =
-  %Q{thing = [
+  %(thing = [
   [:one],
   [
     :two,
     :three
   ]
-]}
+])
 
 INDENT_OK['assignment_twolevel_paren_multistatement'] =
-  %Q{result = Integer(
+  %(result = Integer(
   String.new(
     '1'
   ).to_i,
   16
-)}
+))
 
 INDENT_OK['method_call_multistatement'] =
-  %Q{my_method_with_many_params(one, two,
+  %(my_method_with_many_params(one, two,
   three,
   four,
-  five)}
+  five))
 
 INDENT_OK['method_call_multistatement_trailing_comment'] =
-  %Q{my_method_with_many_params(one, two,
+  %(my_method_with_many_params(one, two,
   three,    # comment
   four,
-  five)}
+  five))
 
 INDENT_OK['method_call_multistatement_lonely_paren'] =
-  %Q{my_method_with_many_params(one, two,
+  %(my_method_with_many_params(one, two,
   three,
   four,
   five
-)}
+))
 
 INDENT_OK['method_call_multistatement_lonely_paren_trailing_comment'] =
-  %Q{my_method_with_many_params(one, two,  # comment
+  %(my_method_with_many_params(one, two,  # comment
   three,
   four,
   five
-)}
+))
 
 #-------------------------------------------------------------------------------
 # Continuation keywords
 #-------------------------------------------------------------------------------
 INDENT_OK['rescue_ending_with_comma'] =
-  %Q{begin
+  %(begin
   ssh.upload source, dest
   @logger.info "Successfully copied the file \#{source} to " +
     "\#{@config[:scp_hostname]}:\#{dest}."
@@ -144,10 +144,10 @@ rescue SocketError, ArgumentError, SystemCallError,
   Net::SCP::Exception, Timeout::Error => ex
   @logger.error "Failed to copy the file \#{source} to \#{dest} due to " +
     ex.message
-end}
+end)
 
 INDENT_OK['rescue_ending_with_comma_trailing_comment'] =
-  %Q{begin
+  %(begin
   ssh.upload source, dest
   @logger.info "Successfully copied the file \#{source} to " +
     "\#{@config[:scp_hostname]}:\#{dest}."
@@ -155,79 +155,79 @@ rescue SocketError, ArgumentError, SystemCallError,     # comment
   Net::SCP::Exception, Timeout::Error => ex
   @logger.error "Failed to copy the file \#{source} to \#{dest} due to " +
     ex.message
-end}
+end)
 
 INDENT_OK['def_rescue'] =
-  %Q{def some_method
+  %(def some_method
   do_something(one, two)
 rescue => e
   log 'It didn't work.'
   raise e
-end}
+end)
 
 INDENT_OK['keyword_ending_with_period'] =
-  %Q{if [].
+  %(if [].
   empty?
   puts 'hi'
-end}
+end)
 
 INDENT_OK['keyword_ending_with_period_trailing_comment'] =
-  %Q{if [].   # comment
+  %(if [].   # comment
   empty?
   puts 'hi'
-end}
+end)
 
 INDENT_OK['def'] =
-  %Q{def a_method
-end}
+  %(def a_method
+end)
 
 INDENT_OK['def_empty'] =
-  %Q{def a_method
+  %(def a_method
 
-end}
+end)
 
 INDENT_OK['nested_def'] =
-  %Q{def first_method
+  %(def first_method
   def second_method
     puts 'hi'
   end
-end}
+end)
 
 INDENT_OK['nested_class'] =
-  %Q{class MyClass
+  %(class MyClass
   class AnotherClass
   end
-end}
+end)
 
 INDENT_OK['require_class_singlestatement'] =
-  %Q{require 'time'
+  %(require 'time'
 
 class MyClass
   include Stuff
-end}
+end)
 
 INDENT_OK['class_as_symbol'] =
-  %Q{INDENT_OK = {}
+  %(INDENT_OK = {}
 
 INDENT_OK[:class] =
   %Q{class MyClass
 end}
 
 INDENT_OK[:one_line_class] =
-  %Q{class MyClass; end}}
+  %Q{class MyClass; end})
 
 INDENT_OK['require_class_singlestatement_def'] =
-  %Q{require 'time'
+  %(require 'time'
 
 class MyClass
   include Stuff
 
   def a_method
   end
-end}
+end)
 
 INDENT_OK['require_class_singlestatement_def_content'] =
-  %Q{require 'time'
+  %(require 'time'
 
 class MyClass
   include Stuff
@@ -235,201 +235,201 @@ class MyClass
   def a_method
     puts 'hello'
   end
-end}
+end)
 
 INDENT_OK['if_modifier'] =
-  %Q{puts 'hi' if nil.nil?}
+  %(puts 'hi' if nil.nil?)
 
 INDENT_OK['if_modifier2'] =
-  %Q{start_key_registration_server if @profiles.values.include? :SM5000}
+  %(start_key_registration_server if @profiles.values.include? :SM5000)
 
 INDENT_OK['def_return_if_modifier'] =
-  %Q{def a_method
+  %(def a_method
   return @something if @something
-end}
+end)
 
 INDENT_OK['unless_modifier'] =
-  %Q{puts 'hi' unless nil.nil?}
+  %(puts 'hi' unless nil.nil?)
 
 INDENT_OK['def_return_unless_modifier'] =
-  %Q{def a_method
+  %(def a_method
   return @something unless @something
-end}
+end)
 
 INDENT_OK['multi_line_if_with_trailing_andop'] =
-  %Q{unless Tim::Runner.configuration[:scp_hostname].nil?
+  %(unless Tim::Runner.configuration[:scp_hostname].nil?
   @reporter.secure_copy if Tim::Runner.configuration[:scp_username] &&
     Tim::Runner.configuration[:scp_password]
-end}
+end)
 
 INDENT_OK['while_within_single_line_block'] =
-  %Q{Timeout::timeout(DEVICE_TIMEOUT) { sleep(0.5) while @device_server.urls.nil? }}
+  %(Timeout::timeout(DEVICE_TIMEOUT) { sleep(0.5) while @device_server.urls.nil? })
 
 INDENT_OK['case_whens_level'] =
-  %Q{def my_method
+  %(def my_method
   case true
   when true
     puts 'stuff'
   when false
     puts 'blah blah'
   end
-end}
+end)
 
 INDENT_OK['case_strings_in_strings'] =
-  %Q{case type
+  %(case type
 when :output
   "I like to \#{eval('puts')}, but should be \#{eval('print')}"
 when :input
   "Gimme \#{eval('gets')}!"
-end}
+end)
 
 =begin
 INDENT_OK['case_whens_in'] =
-  %Q{def my_method
+  %(def my_method
   case true
     when true
       puts "stuff"
     when false
       puts "blah blah"
   end
-end}
+end)
 =end
 
 INDENT_OK['while_do_loop'] =
-  %Q{while true do
+  %(while true do
   puts 'something'
-end}
+end)
 
 INDENT_OK['while_do_loop2'] =
-  %Q{i = 0;
+  %(i = 0;
 num = 5;
 
 while i < num do
   puts("Inside the loop i = \#{i}");
   i +=1;
-end}
+end)
 
 INDENT_OK['until_do_loop'] =
-  %Q{until true do
+  %(until true do
   puts 'something'
-end}
+end)
 
 INDENT_OK['until_do_loop2'] =
-  %Q{i = 0;
+  %(i = 0;
 num = 5;
 
 until i > num  do
   puts("Inside the loop i = \#{i}");
   i +=1;
-end}
+end)
 
 INDENT_OK['for_do_loop'] =
-  %Q{for i in 1..100 do
+  %(for i in 1..100 do
   puts i
-end}
+end)
 
 INDENT_OK['loop_do_loop'] =
-  %Q{loop do
+  %(loop do
   puts 'looping'
-end}
+end)
 
 INDENT_OK['while_as_modifier_loop'] =
-  %Q{i = 0;
+  %(i = 0;
 num = 5;
 begin
   puts("Inside the loop i = \#{i}");
   i +=1;
-end while i < num}
+end while i < num)
 
 INDENT_OK['until_as_modifier_loop'] =
-  %Q{i = 0;
+  %(i = 0;
 num = 5;
 begin
   puts("Inside the loop i = \#{i}");
   i +=1;
-end until i > num}
+end until i > num)
 
 INDENT_OK['for_with_break_loop'] =
-  %Q{for i in 0..5
+  %(for i in 0..5
   if i > 2 then
     break
   end
   puts "Value of local variable is \#{i}"
-end}
+end)
 
 INDENT_OK['for_with_next_loop'] =
-  %Q{for i in 0..5
+  %(for i in 0..5
   if i < 2 then
     next
   end
   puts "Value of local variable is \#{i}"
-end}
+end)
 
 INDENT_OK['for_with_redo_loop'] =
-  %Q{for i in 0..5
+  %(for i in 0..5
   if i < 2 then
     puts "Value of local variable is \#{i}"
     redo
   end
-end}
+end)
 
 INDENT_OK['for_with_retry_loop'] =
-  %Q{for i in 1..5
+  %(for i in 1..5
   retry if i > 2
   puts "Value of local variable is \#{i}"
-end}
+end)
 
 INDENT_OK['loop_with_braces'] =
-  %Q<loop {
+  %(loop {
   puts 'stuff'
-}>
+})
 
 #----------- Braces ----------#
 INDENT_OK['single_line_braces'] =
-  %Q<{ one: 1, two: 2 }>
+  %({ one: 1, two: 2 })
 
 INDENT_OK['single_line_braces_as_t_string'] =
-  %Q<%Q{this is a t string!}>
+  %(%Q{this is a t string!})
 
 INDENT_OK['multi_line_braces'] =
-  %Q<{ one: 1,
-  two: 2 }>
+  %({ one: 1,
+  two: 2 })
 
 INDENT_OK['multi_line_braces_as_t_string'] =
-  %Q<%Q{this is a t string!
-suckaaaaaa!}>
+  %(%Q{this is a t string!
+suckaaaaaa!})
 
-# For some reason, Ruby doesn't like '%Q<> here.  Using [] instead.
+# For some reason, Ruby doesn't like '%Q<> here.
 INDENT_OK['multi_line_lonely_braces'] =
-  %Q[{
+  %({
   :one => 'one', :two => 'two',
   :three => 'three'
-}]
+})
 
 INDENT_OK['multi_line_lonely_braces_as_t_string'] =
-  %Q<%Q{
+  %(%Q{
 this is a t string!
 suckaaaaaa!
-}>
+})
 
 INDENT_OK['multi_line_braces_embedded_arrays'] =
-  %Q[{
+  %({
   :one => ['one', 17, {}], :two => ['two'],
   :three => 'three'
-}]
+})
 
 INDENT_OK['braces_combo'] =
-  %Q<{ three: 3 }
+  %({ three: 3 }
 {
   three: 3 }
 { three: 3
 }
 {
   three: 3
-}>
+})
 
 INDENT_OK['deep_hash_with_rockets'] =
-  %Q[im_deep =
+  %(im_deep =
   { 'one' =>
     { '1' =>
       { 'a' => 'A',
@@ -438,10 +438,10 @@ INDENT_OK['deep_hash_with_rockets'] =
       '2' =>
       { 'd' => 'D',
         'e' => 'E',
-        'f' => 'F' } } }]
+        'f' => 'F' } } })
 
 INDENT_OK['embedded_strings_in_embedded_strings'] =
-  %q[def friendly_time(time)
+  %q(def friendly_time(time)
   if hours < 24
     "#{(hours > 0) ? "#{hours} hour" : '' }#{(hours > 1) ? 's' : ''}" +
       " #{(mins > 0) ? "#{mins} minute" : '' }#{(mins > 1) ? 's' : ''}" +
@@ -449,116 +449,116 @@ INDENT_OK['embedded_strings_in_embedded_strings'] =
   else
     time.to_s
   end
-end]
+end)
 
 #----------- Brackets ----------#
 INDENT_OK['single_line_brackets'] =
-  %Q{['one', 'two', 'three']}
+  %(['one', 'two', 'three'])
 
 INDENT_OK['single_line_brackets_as_t_string'] =
-  %Q{%Q[this is a t string!]}
+  %(%Q[this is a t string!])
 
 INDENT_OK['multi_line_brackets'] =
-  %Q{['one',
+  %(['one',
   'two',
-  'three']}
+  'three'])
 
 INDENT_OK['multi_line_brackets_as_t_string'] =
-  %Q{%Q[this is a t string!
+  %(%Q[this is a t string!
                                 it doesn't matter that this is way over here.
-suckaaaaaa!]}
+suckaaaaaa!])
 
 INDENT_OK['multi_line_lonely_brackets'] =
-  %Q{[
+  %([
   'one',
   'two',
   'three'
-]}
+])
 
 INDENT_OK['multi_line_lonely_brackets_as_t_string'] =
-  %Q{%Q[
+  %(%Q[
 this is a t string!
                                 it doesn't matter that this is way over here.
 suckaaaaaa!
-]}
+])
 
 INDENT_OK['multi_line_brackets_embedded_hashes'] =
-  %Q{summary_table.rows << [{ value: 'File', align: :center },
-  { value: 'Total Problems', align: :center }]}
+  %(summary_table.rows << [{ value: 'File', align: :center },
+  { value: 'Total Problems', align: :center }])
 
 INDENT_OK['brackets_combo'] =
-  %Q{[2]
+  %([2]
 [
   2]
 [2
 ]
 [
   2
-]}
+])
 
 #----------- Parens ----------#
 
 INDENT_OK['single_line_parens'] =
-  %Q{(true || false)}
+  %((true || false))
 
 INDENT_OK['single_line_parens_as_t_string'] =
-  %Q{%Q(this is a t string!)}
+  %(%Q(this is a t string!))
 
 INDENT_OK['multi_line_parens'] =
-  %Q{my_method(first_argument, second_arg,
-  third_arg)}
+  %(my_method(first_argument, second_arg,
+  third_arg))
 
 INDENT_OK['multi_line_parens_as_t_string'] =
-  %Q{%Q(this is a t string!
+  %(%Q(this is a t string!
 and i'm not going
-anywhere!')}
+anywhere!'))
 
 INDENT_OK['multi_line_lonely_parens'] =
-  %Q{my_method(
+  %(my_method(
   first_argument
-)}
+))
 
 INDENT_OK['multi_line_lonely_parens_with_commas'] =
-  %Q{my_method(
+  %(my_method(
   first_argument, second_arg,
   third_arg
-)}
+))
 
 INDENT_OK['multi_line_lonely_parens_as_t_string'] =
-  %Q{%Q(
+  %(%Q(
 this is a t string!
 and i'm not going
 anywhere!'
-)}
+))
 
 INDENT_OK['parens_combo'] =
-  %Q{(1)
+  %((1)
 (
   1)
 (1
 )
 (
   1
-)}
+))
 
 
 #-------------------------------------------------------------------------------
 # Operators
 #-------------------------------------------------------------------------------
 INDENT_OK['multi_line_ops'] =
-  %Q{2 -
+  %(2 -
   1 -
   0 +
-  12}
+  12)
 
 INDENT_OK['multi_line_andop_in_method'] =
-  %Q{def end_of_multiline_string?(lexed_line_output)
+  %(def end_of_multiline_string?(lexed_line_output)
   lexed_line_output.any? { |e| e[1] == :on_tstring_end } &&
     lexed_line_output.none? { |e| e[1] == :on_tstring_beg }
-end}
+end)
 
 INDENT_OK['multi_line_rshift_in_method'] =
-  %Q{rule(:transport_specifier) do
+  %(rule(:transport_specifier) do
   match('[A-Za-z]').repeat(3).as(:streaming_protocol) >> forward_slash >>
     match('[A-Za-z]').repeat(3).as(:profile) >>
     (forward_slash >> match('[A-Za-z]').repeat(3).as(:transport_protocol)).maybe
@@ -571,18 +571,18 @@ end
 
 rule(:ttl) do
   str('ttl=') >> match('[\d]').repeat(1, 3).as(:ttl)
-end}
+end)
 
 INDENT_OK['multi_line_string_concat_with_plus'] =
-  %Q{DVR_SSDP_NOTIFICATION_TEMPLATE = File.dirname(__FILE__) +
-  '/profiles/DVR5000/ssdp_notification.erb'}
+  %(DVR_SSDP_NOTIFICATION_TEMPLATE = File.dirname(__FILE__) +
+  '/profiles/DVR5000/ssdp_notification.erb')
 
 INDENT_OK['multi_line_string_concat_with_plus_in_parens'] =
-  %Q{DVR_CONFIG_RENDERER = Erubis::Eruby.new(File.read File.dirname(__FILE__) +
-  '/profiles/DVR5000/device_config.xml.erb')}
+  %(DVR_CONFIG_RENDERER = Erubis::Eruby.new(File.read File.dirname(__FILE__) +
+  '/profiles/DVR5000/device_config.xml.erb'))
 
 INDENT_OK['multi_line_string_concat_twice'] =
-  %Q{unless Tim::Runner.configuration[:email].nil? ||
+  %(unless Tim::Runner.configuration[:email].nil? ||
   Tim::Runner.configuration[:email].empty?
   Tim::EmailReporter.subject_status ||= subject_status
   @email_reporter.send_email
@@ -592,13 +592,13 @@ def print_iteration_start iteration_number
   iteration_message = "Running Iteration \#{iteration_number} of " +
     @config[:suite_iterations].to_s
   @logger.info bar(iteration_message)
-end}
+end)
 
 #-------------------------------------------------------------------------------
 # Method calls
 #-------------------------------------------------------------------------------
 INDENT_OK['multi_line_method_call'] =
-  %Q{def initialize(raw_response)
+  %(def initialize(raw_response)
   if raw_response.nil? || raw_response.empty?
     raise RTSP::Error,
       "\#{self.class} received nil string--this shouldn't happen."
@@ -609,39 +609,39 @@ INDENT_OK['multi_line_method_call'] =
   head, body = split_head_and_body_from @raw_response
   parse_head(head)
   @body = parse_body(body)
-end}
+end)
 
 INDENT_OK['multi_line_method_call_ends_with_period'] =
-  %Q{unless streamer == MulticastStreamer.instance
+  %(unless streamer == MulticastStreamer.instance
   streamer.state = :DISCONNECTED
   UnicastStreamer.pool << streamer unless UnicastStreamer.pool.
     member? streamer
-end}
+end)
 
 INDENT_OK['multi_line_method_call_ends_with_many_periods'] =
-  %Q{my_hashie.first_level.
+  %(my_hashie.first_level.
   second_level.
-  third_level}
+  third_level)
 
 =begin
 INDENT_OK['method_closing_lonely_paren'] =
-  %Q{def your_thing(one
+  %(def your_thing(one
   )
-end}
+end)
 =end
 
 INDENT_OK['method_lonely_args'] =
-  %Q{def your_thing(
+  %(def your_thing(
   one
 )
   puts 'stuff'
-end}
+end)
 
 #------------------------------------------------------------------------------
 # If + logical operators
 #------------------------------------------------------------------------------
 INDENT_OK['multi_line_if_logical_and'] =
-  %Q{if @indentation_ruler.op_statement_nesting.empty? &&
+  %(if @indentation_ruler.op_statement_nesting.empty? &&
   @indentation_ruler.tstring_nesting.empty? &&
   @indentation_ruler.paren_nesting.empty? &&
   @indentation_ruler.brace_nesting.empty? &&
@@ -654,35 +654,35 @@ INDENT_OK['multi_line_if_logical_and'] =
     @indentation_ruler.last_comma_statement_line = lineno
     log "last: \#{@indentation_ruler.last_comma_statement_line}"
   end
-end}
+end)
 
 INDENT_OK['multi_line_each_block'] =
-  %Q{style.each do |ruler_name, value|
+  %(style.each do |ruler_name, value|
   instance_eval(
     "Tailor::Rulers::\#{camelize(ruler_name.to_s)}Ruler.new(\#{value})"
   )
   parent_ruler.add_child_ruler(ruler)
-end}
+end)
 
 INDENT_OK['multi_line_each_block_with_op_and_parens'] =
-  %Q{style.each do |ruler_name, value|
+  %(style.each do |ruler_name, value|
   ruler =
     instance_eval(
       "Tailor::Rulers::\#{camelize(ruler_name.to_s)}Ruler.new(\#{value})"
     )
   parent_ruler.add_child_ruler(ruler)
-end}
+end)
 
 INDENT_OK['do_end_block_in_parens'] =
-  %Q{begin
+  %(begin
   throw(:result, sexp_line.flatten.compact.any? do |s|
     s == MODIFIERS[self]
   end)
 rescue NoMethodError
-end}
+end)
 
 INDENT_OK['block_in_block_ends_on_same_line'] =
-  %Q{%w{
+  %(%w{
   foo
   bar
   baz
@@ -691,53 +691,53 @@ INDENT_OK['block_in_block_ends_on_same_line'] =
     puts 'stuff'
   end end
 
-puts 'post ends'}
+puts 'post ends')
 
 =begin
 INDENT_OK['rparen_and_do_same_line'] =
-  %Q{opt.on('-c', '--config-file FILE',
+  %(opt.on('-c', '--config-file FILE',
   "Use a specific config file.") do |config|
   options.config_file = config
-end}
+end)
 =end
 
 #-------------------------------------------------------------------------------
 # Single-line keywords
 #-------------------------------------------------------------------------------
 INDENT_OK['single_line_begin_rescue_end'] =
-  %Q{def log
+  %(def log
   l = begin; lineno; rescue; '<EOF>'; end
   c = begin; column; rescue; '<EOF>'; end
   subclass_name = self.class.to_s.sub(/^Tailor::/, '')
   args.first.insert(0, "<\#{subclass_name}> \#{l}[\#{c}]: ")
   Tailor::Logger.log(*args)
-end}
+end)
 
 #-------------------------------------------------------------------------------
 # Combos
 #-------------------------------------------------------------------------------
 INDENT_OK['combo1'] =
-  %Q{def set_default_smtp
+  %(def set_default_smtp
   Mail.defaults do
     @config = Tim::Runner.configuration
     delivery_method(:smtp,
       { :address => @config[:smtp_server],
         :port => @config[:smtp_server_port] })
   end
-end}
+end)
 
 INDENT_OK['combo2'] =
-  %Q{class C
+  %(class C
 
   send :each do
     def foo
     end
   end
 
-end}
+end)
 
 INDENT_OK['combo3'] =
-  %Q{def report_turducken(results, performance_results)
+  %(def report_turducken(results, performance_results)
   stuffing[:log_files] = { "\#{File.basename @logger.log_file_location}/path" =>
     File.read(@logger.log_file_location).gsub(/(?<f><)(?<q>\\/)?(?<w>\\w)/,
       '\\k<f>!\\k<q>\\k<w>') }.merge remote_logs
@@ -751,24 +751,24 @@ INDENT_OK['combo3'] =
   end
 
   suite_result_url
-end}
+end)
 
 INDENT_OK['brace_bracket_paren_combo1'] =
-  %Q{[{ :one => your_thing(
+  %([{ :one => your_thing(
   1)
 }
-]}
+])
 
 INDENT_OK['paren_comma_combo1'] =
-  %Q{def do_something
+  %(def do_something
   self[:log_file_location] = Time.now.strftime(File.join(Tim::LOG_DIR,
     "\#{self[:product]}_%Y-%m-%d_%H-%M-%S.log"))
 
   handle_arguments arg_list
-end}
+end)
 
 INDENT_OK['line_ends_with_label'] =
-  %Q{options = {
+  %(options = {
   actual_trailing_spaces:
     lexed_line.last_non_line_feed_event.last.size
-}}
+})

--- a/spec/support/horizontal_spacing_cases.rb
+++ b/spec/support/horizontal_spacing_cases.rb
@@ -2,8 +2,8 @@ H_SPACING_OK = {}
 
 H_SPACING_OK['short_line_no_newline'] = '#' * 79
 H_SPACING_OK['short_line_newline_at_81'] =
-  %Q{'#{'#' * 78}'
-}
+  %('#{'#' * 78}'
+)
 
 =begin
 H_SPACING_OK['line_split_by_backslash'] =
@@ -17,120 +17,119 @@ end}
 #-------------------------------------------------------------------------------
 # Comma spacing
 #-------------------------------------------------------------------------------
-H_SPACING_OK['space_after_comma_in_array'] = %Q{[1, 2]}
+H_SPACING_OK['space_after_comma_in_array'] = %([1, 2])
 
-H_SPACING_OK['trailing_comma'] = %Q{def thing(one, two,
+H_SPACING_OK['trailing_comma'] = %(def thing(one, two,
   three)
-end}
+end)
 
 H_SPACING_OK['trailing_comma_with_trailing_comment'] =
-  %Q{def thing(one, two,  # Comment!
+  %(def thing(one, two,  # Comment!
   three)
-end}
+end)
 
-H_SPACING_OK['no_before_comma_in_array'] = %Q{[1, 2]}
+H_SPACING_OK['no_before_comma_in_array'] = %([1, 2])
 H_SPACING_OK['line_ends_with_backslash'] =
-  %Q{{ :thing => a_thing,\\
-  :thing2 => another_thing }}
+  %({ :thing => a_thing,\\
+  :thing2 => another_thing })
 
 #-------------------------------------------------------------------------------
 # Braces
 #-------------------------------------------------------------------------------
-H_SPACING_OK['empty_hash'] = %Q{{}}
-H_SPACING_OK['single_line_hash'] = %Q{{ :one => 'one' }}
-H_SPACING_OK['single_line_hash_lonely_braces'] = %Q{{
+H_SPACING_OK['empty_hash'] = %({})
+H_SPACING_OK['single_line_hash'] = %({ :one => 'one' })
+H_SPACING_OK['single_line_hash_lonely_braces'] = %({
   :one => 'one'
-}}
+})
 
 H_SPACING_OK['hash_as_param_in_parens'] =
-  %Q{add_headers({ content_length: new_body.length })}
+  %(add_headers({ content_length: new_body.length }))
 
-H_SPACING_OK['two_line_hash'] = %Q{{ :one =>
-  'one' }}
+H_SPACING_OK['two_line_hash'] = %({ :one =>
+  'one' })
 
-H_SPACING_OK['two_line_hash_trailing_comment'] = %Q{{ :one =>    # comment
-  'one' }}
+H_SPACING_OK['two_line_hash_trailing_comment'] = %({ :one =>    # comment
+  'one' })
 
-H_SPACING_OK['three_line_hash'] = %Q{{ :one =>
+H_SPACING_OK['three_line_hash'] = %({ :one =>
   'one', :two =>
-  'two' }}
+  'two' })
 
-H_SPACING_OK['single_line_block'] = %Q{1..10.times { |n| puts number }}
-H_SPACING_OK['multi_line_braces_block'] = %Q{1..10.times { |n|
-  puts number }}
+H_SPACING_OK['single_line_block'] = %(1..10.times { |n| puts number })
+H_SPACING_OK['multi_line_braces_block'] = %(1..10.times { |n|
+  puts number })
 
-H_SPACING_OK['multi_line_qword_using_braces'] = %Q{%w{
+H_SPACING_OK['multi_line_qword_using_braces'] = %(%w{
   foo
   bar
   baz
 }.each do |whatevs|
   bla
-end}
+end)
 
 H_SPACING_OK['empty_hash_in_multi_line_statement'] =
-  %Q{if true
+  %(if true
   {}
-end}
+end)
 
 H_SPACING_OK['multi_line_hash_in_multi_line_statement'] =
-  %Q{if true
+  %(if true
   options = {
     one: 1
   }
-end}
+end)
 
-H_SPACING_OK['single_line_string_interp'] = %Q{`\#{IFCONFIG} | grep \#{ip}`}
+H_SPACING_OK['single_line_string_interp'] = %(`\#{IFCONFIG} | grep \#{ip}`)
 H_SPACING_OK['single_line_block_in_string_interp'] =
-  %Q{"I did this \#{1..10.times { |n| n }} times."}
+  %("I did this \#{1..10.times { |n| n }} times.")
 
 H_SPACING_OK['empty_hash_in_string_in_block'] =
-  %Q{[1].map { |n| { :first => "\#{n}-\#{{}}" } }}
+  %([1].map { |n| { :first => "\#{n}-\#{{}}" } })
 
 H_SPACING_OK['string_interp_with_colonop'] =
-  %Q{"\#{::Rails.root + 'file'}"}
+  %("\#{::Rails.root + 'file'}")
 
 
 
 #-------------------------------------------------------------------------------
 # Brackets
 #-------------------------------------------------------------------------------
-H_SPACING_OK['empty_array'] = %Q{[]}
-H_SPACING_OK['simple_array'] = %Q{[1, 2, 3]}
-H_SPACING_OK['two_d_array'] = %Q{[[1, 2, 3], ['a', 'b', 'c']]}
-H_SPACING_OK['hash_key_reference'] = %Q{thing[:one]}
+H_SPACING_OK['empty_array'] = %([])
+H_SPACING_OK['simple_array'] = %([1, 2, 3])
+H_SPACING_OK['two_d_array'] = %([[1, 2, 3], ['a', 'b', 'c']])
+H_SPACING_OK['hash_key_reference'] = %(thing[:one])
 H_SPACING_OK['array_of_symbols'] =
-  %Q{transition [:active, :reactivated] => :opened}
+  %(transition [:active, :reactivated] => :opened)
 H_SPACING_OK['array_of_hashes'] =
-  %Q{[ { :one => [[1, 2, 3], ['a', 'b', 'c']] },
-  { :two => [[4, 5, 6], ['d', 'e', 'f']] }]}
+  %([ { :one => [[1, 2, 3], ['a', 'b', 'c']] },
+  { :two => [[4, 5, 6], ['d', 'e', 'f']] }])
 
 H_SPACING_OK['simple_array_lonely_brackets'] =
-  %Q{[
+  %([
   1, 2,
   3
-]}
+])
 
 H_SPACING_OK['simple_nested_array_lonely_brackets'] =
-  %Q{def thing
+  %(def thing
   [
     1, 2,
     3
   ]
-end}
-
+end)
 
 H_SPACING_OK['empty_array_in_multi_line_statement'] =
-  %Q{if true
+  %(if true
   []
-end}
+end)
 
 #-------------------------------------------------------------------------------
 # Parens
 #-------------------------------------------------------------------------------
-H_SPACING_OK['empty_parens'] = %Q{def thing(); end}
-H_SPACING_OK['simple_method_call'] = %Q{thing(one, two)}
-H_SPACING_OK['multi_line_method_call'] = %Q{thing(one,
-  two)}
-H_SPACING_OK['multi_line_method_call_lonely_parens'] = %Q{thing(
+H_SPACING_OK['empty_parens'] = %(def thing(); end)
+H_SPACING_OK['simple_method_call'] = %(thing(one, two))
+H_SPACING_OK['multi_line_method_call'] = %(thing(one,
+  two))
+H_SPACING_OK['multi_line_method_call_lonely_parens'] = %(thing(
   one, two
-)}
+))

--- a/spec/support/line_indentation_cases.rb
+++ b/spec/support/line_indentation_cases.rb
@@ -1,11 +1,11 @@
 LINE_INDENT = {}
 
 LINE_INDENT['hash_spans_lines'] =
-  %q{db_connection = { :host => "localhost", :username => 'root',
-  :password => node['db']['password'] }}
+  %(db_connection = { :host => "localhost", :username => 'root',
+  :password => node['db']['password'] })
 
 LINE_INDENT['if_else'] =
-  %q{case "foo"
+  %(case "foo"
 when "foo"
   if node["foo"]["version"].to_f >= 5.5
     default['foo']['service_name'] = "foo"
@@ -14,28 +14,28 @@ when "foo"
     default['foo']['service_name'] = "food"
     default['foo']['pid_file'] = "/var/run/food/food.pid"
   end
-end}
+end)
 
 LINE_INDENT['line_continues_at_same_indentation'] =
-  %q{if someconditional_that == is_really_long.function().stuff() or
+  %(if someconditional_that == is_really_long.function().stuff() or
   another_condition == some_thing
   puts "boop"
-end}
+end)
 
 LINE_INDENT['line_continues_further_indented'] =
-  %q{if someconditional_that == is_really_long.function().stuff() or
+  %(if someconditional_that == is_really_long.function().stuff() or
     another_condition == some_thing
   puts "boop"
-end}
+end)
 
 LINE_INDENT['line_continues_without_nested_statements'] =
-  %q{attribute "foo/password",
+  %(attribute "foo/password",
   :display_name => "Password",
   :description => "Randomly generated password",
-  :default => "randomly generated"}
+  :default => "randomly generated")
 
 LINE_INDENT['minitest_test_cases'] =
-  %q{describe "foo" do
+  %q(describe "foo" do
   it 'includes the disk_free_limit configuration setting' do
     file("#{node['foo']['config_root']}/foo.config").
       must_match /\{disk_free_limit, \{mem_relative, #{node['foo']['df']}/
@@ -44,28 +44,28 @@ LINE_INDENT['minitest_test_cases'] =
     file("#{node['foo']['config_root']}/foo.config").
       must_match /\{vm_memory_high_watermark, #{node['foo']['vm']}/
   end
-end}
+end)
 
 LINE_INDENT['nested_blocks'] =
-  %q{node['foo']['client']['packages'].each do |foo_pack|
+  %(node['foo']['client']['packages'].each do |foo_pack|
   package foo_pkg do
     action :install
   end
-end}
+end)
 
 LINE_INDENT['one_assignment_per_line'] =
-  %q{default['foo']['bar']['apt_key_id'] = 'BD2EFD2A'
+  %(default['foo']['bar']['apt_key_id'] = 'BD2EFD2A'
 default['foo']['bar']['apt_uri'] = "http://repo.example.com/apt"
-default['foo']['bar']['apt_keyserver'] = "keys.example.net"}
+default['foo']['bar']['apt_keyserver'] = "keys.example.net")
 
 LINE_INDENT['parameters_continuation_indent_across_lines'] =
-  %q{def something(waka, baka, bing,
+  %(def something(waka, baka, bing,
     bla, goop, foop)
   stuff
-end}
+end)
 
 LINE_INDENT['parameters_no_continuation_indent_across_lines'] =
-  %q{def something(waka, baka, bing,
+  %(def something(waka, baka, bing,
   bla, goop, foop)
   stuff
-end}
+end)

--- a/spec/support/naming_cases.rb
+++ b/spec/support/naming_cases.rb
@@ -1,26 +1,26 @@
 NAMING_OK = {}
 
 NAMING_OK['single_word_method'] =
-  %Q{def thing
-end}
+  %(def thing
+end)
 
 NAMING_OK['two_word_method'] =
-  %Q{def thing_one
-end}
+  %(def thing_one
+end)
 
 #-------------------------------------------------------------------------------
 NAMING_OK['single_word_class'] =
-  %Q{class Thing
-end}
+  %(class Thing
+end)
 
 NAMING_OK['single_word_module'] =
-  %Q{module Thing
-end}
+  %(module Thing
+end)
 
 NAMING_OK['two_word_class'] =
-  %Q{class ThingOne
-end}
+  %(class ThingOne
+end)
 
 NAMING_OK['two_word_module'] =
-  %Q{module ThingOne
-end}
+  %(module ThingOne
+end)

--- a/spec/support/string_interpolation_cases.rb
+++ b/spec/support/string_interpolation_cases.rb
@@ -1,45 +1,45 @@
 INTERPOLATION = {}
 
 INTERPOLATION['one_variable_interpolated_only'] =
-  %q{puts "#{bing}"
-}
+  %q(puts "#{bing}"
+)
 
 INTERPOLATION['mixed_content_and_expression'] =
-  %q{puts "hello: #{bing}"
-}
+  %q(puts "hello: #{bing}"
+)
 
 INTERPOLATION['no_string'] =
-  %q{puts bing
-}
+  %q(puts bing
+)
 
 INTERPOLATION['two_variables'] =
-  %q{puts "#{bing}#{bar}"
-}
+  %q(puts "#{bing}#{bar}"
+)
 
 INTERPOLATION['two_strings_with_unnecessary_interpolation'] =
-  %q{puts "#{foo}" + "#{bar}"
-}
+  %q(puts "#{foo}" + "#{bar}"
+)
 
 INTERPOLATION['multiline_string_with_unnecessary_interpolation'] =
-  %q{puts "#{foo +
+  %q(puts "#{foo +
 bar -
 baz}"
-}
+)
 
 INTERPOLATION['multiline_word_list'] =
-  %q{%w{
+  %q(%w{
   foo
   bar
   baz
-}}
+})
 
 INTERPOLATION['nested_interpolation'] =
-  %q[def friendly_time(time)
+  %q(def friendly_time(time)
   if hours < 24
     "#{(hours > 0) ? "#{hours} hour" : '' }#{(hours > 1) ? 's' : ''}" +
       " #{(mins > 0) ? "#{mins} minute" : '' }#{(mins > 1) ? 's' : ''}" +
-      " #{seconds} second#{(seconds > 1) ? "s" : ''} ago"
+      " #{seconds} second#{(seconds > 1) ? 's' : ''} ago"
   else
     time.to_s
   end
-end]
+end)

--- a/spec/support/string_quoting_cases.rb
+++ b/spec/support/string_quoting_cases.rb
@@ -1,25 +1,25 @@
 QUOTING = {}
 
 QUOTING['single_quotes_no_interpolation'] =
-  %q{foo = 'bar'
-}
+  %q(foo = 'bar'
+)
 
 QUOTING['double_quotes_with_interpolation'] =
-  %q{foo = "bar#{baz}"
-}
+  %q(foo = "bar#{baz}"
+)
 
 QUOTING['double_quotes_no_interpolation'] =
-  %q{foo = "bar"
-}
+  %q(foo = "bar"
+)
 
 QUOTING['double_quotes_no_interpolation_twice'] =
-  %q{foo = "bar" + "baz"
-}
+  %q(foo = "bar" + "baz"
+)
 
 QUOTING['escape_sequence'] =
-  %q{foo = "bar\n"
-}
+  %q(foo = "bar\n"
+)
 
 QUOTING['nested_quotes'] =
-  %q{foo = "foo#{bar('baz')}"
-}
+  %q(foo = "foo#{bar('baz')}"
+)

--- a/spec/support/vertical_spacing_cases.rb
+++ b/spec/support/vertical_spacing_cases.rb
@@ -4,33 +4,33 @@ V_SPACING_OK = {}
 # Class length
 #-------------------------------------------------------------------------------
 V_SPACING_OK['class_five_code_lines'] =
-  %Q{class Party
+  %(class Party
   include Clowns
 
   def barrel_roll
   end
-end}
+end)
 
 V_SPACING_OK['embedded_class_five_code_lines'] =
-  %Q{class Party
+  %(class Party
   class Pizza
     include Cheese
   end
-end}
+end)
 
 #-------------------------------------------------------------------------------
 # Method length
 #-------------------------------------------------------------------------------
 V_SPACING_OK['method_3_code_lines'] =
-  %Q{def thing
+  %(def thing
 
 
   puts 'hi'
-end}
+end)
 
 V_SPACING_OK['embedded_method_3_code_lines'] =
-  %Q{def outter_thing
+  %(def outter_thing
   def thing; puts 'hi'; end
 
 
-end}
+end)

--- a/spec/unit/tailor/cli/options_spec.rb
+++ b/spec/unit/tailor/cli/options_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 require 'tailor/cli/options'
 
+# Module to use in tests.
 module OptionHelpers
   def cli_option(name)
     "--#{name.to_s.gsub('_', '-')}"
   end
+
   def option_value(name, value)
     options = Tailor::CLI::Options.parse!([cli_option(name), value])
     options.style[name]
@@ -13,6 +15,7 @@ end
 
 describe Tailor::CLI::Options do
   include OptionHelpers
+
   describe '#parse!' do
     [
       :indentation_spaces,
@@ -31,20 +34,23 @@ describe Tailor::CLI::Options do
       :spaces_in_empty_braces,
       :trailing_newlines
     ].each do |o|
-        it 'parses a valid numeric argument correct' do
-          expect(option_value(o, '1')).to eq 1
-        end
-        it 'marks the ruler as off if the option is specified as "off"' do
-          expect(option_value(o, 'off')).to eq :off
-        end
-        it 'marks a ruler as off if the option is specified as "false"' do
-          expect(option_value(o, 'false')).to eq :off
-        end
-        it 'raises if the argument is otherwise not an integer' do
-          expect do
-            option_value(o, 'not-an-integer')
-          end.to raise_error(OptionParser::InvalidArgument)
-        end
+      it 'parses a valid numeric argument correct' do
+        expect(option_value(o, '1')).to eq 1
       end
+
+      it 'marks the ruler as off if the option is specified as "off"' do
+        expect(option_value(o, 'off')).to eq :off
+      end
+
+      it 'marks a ruler as off if the option is specified as "false"' do
+        expect(option_value(o, 'false')).to eq :off
+      end
+
+      it 'raises if the argument is otherwise not an integer' do
+        expect do
+          option_value(o, 'not-an-integer')
+        end.to raise_error(OptionParser::InvalidArgument)
+      end
+    end
   end
 end

--- a/spec/unit/tailor/cli_spec.rb
+++ b/spec/unit/tailor/cli_spec.rb
@@ -1,24 +1,18 @@
 require 'spec_helper'
 require 'tailor/cli'
 
-
 describe Tailor::CLI do
   let(:args) { [] }
   let(:options) { double 'Options', show_config: false }
 
   let(:config) do
-    double 'Tailor::Configuration',
-      file_sets: nil, formatters: nil, load!: nil
+    double 'Tailor::Configuration', file_sets: nil, formatters: nil, load!: nil
   end
 
   before do
-    Tailor::Configuration.stub(:new).and_return config
-    Tailor::Critic.stub(:new)
-    Tailor::Reporter.stub(:new)
-  end
-
-  after do
-    Tailor::Configuration.unstub(:new)
+    allow(Tailor::Configuration).to receive(:new).and_return config
+    allow(Tailor::Critic).to receive(:new)
+    allow(Tailor::Reporter).to receive(:new)
   end
 
   subject { Tailor::CLI.new(args) }
@@ -26,39 +20,40 @@ describe Tailor::CLI do
   describe '::run' do
     it "creates an instance of Tailor::CLI and calls that object's #execute!" do
       cli = double 'Tailor::CLI'
-      cli.should_receive(:execute!)
-      Tailor::CLI.should_receive(:new).and_return cli
+      expect(cli).to receive(:execute!)
+      expect(Tailor::CLI).to receive(:new).and_return cli
       Tailor::CLI.run([])
     end
   end
 
   describe '#initialize' do
-    let(:args) { %w[last] }
+    let(:args) { %w(last) }
 
     it 'uses Options to parse the args' do
-      Tailor::Configuration.stub(:new).and_return config
-      Tailor::Critic.stub(:new)
-      Tailor::Reporter.stub(:new)
-      Tailor::CLI::Options.should_receive(:parse!).with(args).and_return options
+      allow(Tailor::Configuration).to receive(:new).and_return config
+      allow(Tailor::Critic).to receive(:new)
+      allow(Tailor::Reporter).to receive(:new)
+      expect(Tailor::CLI::Options).to receive(:parse!).
+        with(args).and_return options
 
       Tailor::CLI.new(args)
     end
 
     it 'creates a new Configuration from the file/dir and options' do
-      Tailor::CLI::Options.stub(:parse!).and_return(options)
-      Tailor::Configuration.should_receive(:new).
-        with(args, options).and_return config
+      allow(Tailor::CLI::Options).to receive(:parse!).and_return(options)
+      expect(Tailor::Configuration).to receive(:new).with(args, options).
+        and_return config
       Tailor::Critic.stub(:new)
 
       Tailor::CLI.new(args)
     end
 
     context 'options.show_config is true' do
-
+      pending
     end
 
     context 'options.show_config is false' do
-
+      pending
     end
   end
 
@@ -67,26 +62,21 @@ describe Tailor::CLI do
     let(:critic) { double 'Tailor::Critic', problem_count: 0 }
 
     before do
-      Tailor::Critic.stub(:new).and_return(critic)
-      Tailor::Reporter.stub(:new).and_return(reporter)
+      allow(Tailor::Critic).to receive(:new).and_return(critic)
+      allow(Tailor::Reporter).to receive(:new).and_return(reporter)
       subject.instance_variable_set(:@critic, critic)
       subject.instance_variable_set(:@reporter, reporter)
-    end
-
-    after do
-      Tailor::Critic.unstub(:new)
-      Tailor::Reporter.unstub(:new)
     end
 
     it 'calls @critic.critique and yields file problems and the label' do
       problems_for_file = {}
       label = :test
-      config.should_receive(:output_file)
-      critic.stub(:problem_count).and_return 1
-      critic.stub(:problems)
-      critic.stub(:critique).and_yield(problems_for_file, label)
-      reporter.stub(:summary_report)
-      reporter.should_receive(:file_report).with(problems_for_file, label)
+      expect(config).to receive(:output_file)
+      allow(critic).to receive(:problem_count).and_return 1
+      allow(critic).to receive(:problems)
+      allow(critic).to receive(:critique).and_yield(problems_for_file, label)
+      allow(reporter).to receive(:summary_report)
+      expect(reporter).to receive(:file_report).with(problems_for_file, label)
 
       subject.execute!
     end
@@ -96,20 +86,16 @@ describe Tailor::CLI do
     let(:critic) { double 'Tailor::Critic', problem_count: 0 }
 
     before do
-      Tailor::Critic.stub(:new).and_return(critic)
+      allow(Tailor::Critic).to receive(:new).and_return(critic)
       subject.instance_variable_set(:@critic, critic)
-    end
-
-    after do
-      Tailor::Critic.unstub(:new)
     end
 
     it 'calls @critic.critique and return @critique.problems hash' do
       problems = {}
-      critic.should_receive(:critique)
-      critic.should_receive(:problems).and_return(problems)
+      expect(critic).to receive(:critique)
+      expect(critic).to receive(:problems).and_return(problems)
 
-      subject.result.should == problems
+      expect(subject.result).to eq problems
     end
   end
 end

--- a/spec/unit/tailor/composite_observable_spec.rb
+++ b/spec/unit/tailor/composite_observable_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'tailor/composite_observable'
 
-
+# Class to use for tests.
 class Tester
   include Tailor::CompositeObservable
 end

--- a/spec/unit/tailor/configuration/file_set_spec.rb
+++ b/spec/unit/tailor/configuration/file_set_spec.rb
@@ -30,7 +30,7 @@ describe Tailor::Configuration::FileSet do
 
       it 'returns the Array with expanded file paths' do
         expect(subject.instance_eval { build_file_list(['test.rb']) }.first).
-          to match(%r[/test.rb$])
+          to match(%r{/test.rb$})
       end
     end
 
@@ -58,7 +58,7 @@ describe Tailor::Configuration::FileSet do
       subject.update_file_list('test2.rb')
       expect(subject.instance_variable_get(:@file_list).size).to eq 2
       expect(subject.instance_variable_get(:@file_list).last).
-        to match(%r[/test2.rb])
+        to match(%r{/test2.rb})
     end
   end
 end

--- a/spec/unit/tailor/configuration/file_set_spec.rb
+++ b/spec/unit/tailor/configuration/file_set_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'tailor/configuration/file_set'
 
-
 describe Tailor::Configuration::FileSet do
   describe '#build_file_list' do
     context 'param is a file name' do
@@ -12,14 +11,14 @@ describe Tailor::Configuration::FileSet do
 
         it 'builds an Array with that file\'s expanded path' do
           new_list = subject.instance_eval { build_file_list('./test.rb') }
-          new_list.should be_an Array
-          new_list.first.should match %r[/test.rb$]
+          expect(new_list).to be_an Array
+          expect(new_list.first).to match(%r{/test.rb$})
         end
       end
 
       context 'the file does not exist' do
         it 'returns an empty Array' do
-          subject.instance_eval { build_file_list('test.rb') }.should == []
+          expect(subject.instance_eval { build_file_list('test.rb') }).to eq []
         end
       end
     end
@@ -30,8 +29,8 @@ describe Tailor::Configuration::FileSet do
       end
 
       it 'returns the Array with expanded file paths' do
-        subject.instance_eval { build_file_list(['test.rb']) }.
-          first.should match %r[/test.rb$]
+        expect(subject.instance_eval { build_file_list(['test.rb']) }.first).
+          to match(%r[/test.rb$])
       end
     end
 
@@ -43,8 +42,8 @@ describe Tailor::Configuration::FileSet do
 
       it 'returns the expanded file paths in that directory' do
         list = subject.instance_eval { build_file_list('test') }
-        list.size.should be 1
-        list.first.should match /.+\/test.rb/
+        expect(list.size).to eq 1
+        expect(list.first).to match(/.+\/test.rb/)
       end
     end
   end
@@ -57,9 +56,9 @@ describe Tailor::Configuration::FileSet do
 
     it 'builds the file list and concats that to @file_list' do
       subject.update_file_list('test2.rb')
-      subject.instance_variable_get(:@file_list).size.should be 2
-      subject.instance_variable_get(:@file_list).last.
-        should match %r[/test2.rb]
+      expect(subject.instance_variable_get(:@file_list).size).to eq 2
+      expect(subject.instance_variable_get(:@file_list).last).
+        to match(%r[/test2.rb])
     end
   end
 end

--- a/spec/unit/tailor/configuration/style_spec.rb
+++ b/spec/unit/tailor/configuration/style_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'tailor/configuration/style'
 
-
 describe Tailor::Configuration::Style do
   describe '.define_property' do
     it 'defines an instance method that takes 2 params' do
@@ -12,7 +11,7 @@ describe Tailor::Configuration::Style do
     it 'allows access to the values via #to_hash' do
       Tailor::Configuration::Style.define_property(:test_method)
       subject.test_method(1, level: :pants)
-      subject.to_hash.should include test_method: [1, { level: :pants }]
+      expect(subject.to_hash).to include test_method: [1, { level: :pants }]
     end
   end
 
@@ -20,134 +19,134 @@ describe Tailor::Configuration::Style do
     describe 'sets up default values' do
       describe 'allow_camel_case_methods' do
         specify do
-          subject.instance_variable_get(:@allow_camel_case_methods).should == [
-            false, { level: :error }]
+          expect(subject.instance_variable_get(:@allow_camel_case_methods)).
+            to eq [false, { level: :error }]
         end
       end
 
       describe 'allow_hard_tabs' do
         specify do
-          subject.instance_variable_get(:@allow_hard_tabs).should == [
-            false, { level: :error }]
+          expect(subject.instance_variable_get(:@allow_hard_tabs)).
+            to eq [false, { level: :error }]
         end
       end
 
       describe 'allow_screaming_snake_case_classes' do
         specify do
-          subject.instance_variable_get(:@allow_screaming_snake_case_classes).
-            should == [false, { level: :error }]
+          expect(subject.instance_variable_get(:@allow_screaming_snake_case_classes)).
+            to eq [false, { level: :error }]
         end
       end
 
       describe 'allow_trailing_line_spaces' do
         specify do
-          subject.instance_variable_get(:@allow_trailing_line_spaces).
-            should == [false, { level: :error }]
+          expect(subject.instance_variable_get(:@allow_trailing_line_spaces)).
+            to eq [false, { level: :error }]
         end
       end
 
       describe 'indentation_spaces' do
         specify do
-          subject.instance_variable_get(:@indentation_spaces).should == [
-            2, { level: :error }]
+          expect(subject.instance_variable_get(:@indentation_spaces)).
+            to eq [2, { level: :error }]
         end
       end
 
       describe 'max_code_lines_in_class' do
         specify do
-          subject.instance_variable_get(:@max_code_lines_in_class).should == [
-            300, { level: :error }]
+          expect(subject.instance_variable_get(:@max_code_lines_in_class)).
+            to eq [300, { level: :error }]
         end
       end
 
       describe 'max_code_lines_in_method' do
         specify do
-          subject.instance_variable_get(:@max_code_lines_in_method).should == [
-            30, { level: :error }]
+          expect(subject.instance_variable_get(:@max_code_lines_in_method)).
+            to eq [30, { level: :error }]
         end
       end
 
       describe 'max_line_length' do
         specify do
-          subject.instance_variable_get(:@max_line_length).should == [
-            80, { level: :error }]
+          expect(subject.instance_variable_get(:@max_line_length)).
+            to eq [80, { level: :error }]
         end
       end
 
       describe 'spaces_after_comma' do
         specify do
-          subject.instance_variable_get(:@spaces_after_comma).should == [
-            1, { level: :error }]
+          expect(subject.instance_variable_get(:@spaces_after_comma)).
+            to eq [1, { level: :error }]
         end
       end
 
       describe 'spaces_after_lbrace' do
         specify do
-          subject.instance_variable_get(:@spaces_after_lbrace).should == [
-            1, { level: :error }]
+          expect(subject.instance_variable_get(:@spaces_after_lbrace)).
+            to eq [1, { level: :error }]
         end
       end
 
       describe 'spaces_after_lbracket' do
         specify do
-          subject.instance_variable_get(:@spaces_after_lbracket).should == [
-            0, { level: :error }]
+          expect(subject.instance_variable_get(:@spaces_after_lbracket)).
+            to eq [0, { level: :error }]
         end
       end
 
       describe 'spaces_after_lparen' do
         specify do
-          subject.instance_variable_get(:@spaces_after_lparen).should == [
-            0, { level: :error }]
+          expect(subject.instance_variable_get(:@spaces_after_lparen)).
+            to eq [0, { level: :error }]
         end
       end
 
       describe 'spaces_before_comma' do
         specify do
-          subject.instance_variable_get(:@spaces_before_comma).should == [
-            0, { level: :error }]
+          expect(subject.instance_variable_get(:@spaces_before_comma)).
+            to eq [0, { level: :error }]
         end
       end
 
       describe 'spaces_before_lbrace' do
         specify do
-          subject.instance_variable_get(:@spaces_before_lbrace).should == [
-            1, { level: :error }]
+          expect(subject.instance_variable_get(:@spaces_before_lbrace)).
+            to eq [1, { level: :error }]
         end
       end
 
       describe 'spaces_before_rbrace' do
         specify do
-          subject.instance_variable_get(:@spaces_before_rbrace).should == [
-            1, { level: :error }]
+          expect(subject.instance_variable_get(:@spaces_before_rbrace)).
+            to eq [1, { level: :error }]
         end
       end
 
       describe 'spaces_before_rbracket' do
         specify do
-          subject.instance_variable_get(:@spaces_before_rbracket).should == [
-            0, { level: :error }]
+          expect(subject.instance_variable_get(:@spaces_before_rbracket)).
+            to eq [0, { level: :error }]
         end
       end
 
       describe 'spaces_before_rparen' do
         specify do
-          subject.instance_variable_get(:@spaces_before_rparen).should == [
-            0, { level: :error }]
+          expect(subject.instance_variable_get(:@spaces_before_rparen)).
+            to eq [0, { level: :error }]
         end
       end
 
       describe 'spaces_in_empty_braces' do
         specify do
-          subject.instance_variable_get(:@spaces_in_empty_braces).should == [
-            0, { level: :error }]
+          expect(subject.instance_variable_get(:@spaces_in_empty_braces)).
+            to eq [0, { level: :error }]
         end
       end
 
       describe 'trailing_newlines' do
         specify do
-          subject.instance_variable_get(:@trailing_newlines).should == [
-            1, { level: :error }]
+          expect(subject.instance_variable_get(:@trailing_newlines)).
+            to eq [1, { level: :error }]
         end
       end
     end
@@ -184,7 +183,7 @@ describe Tailor::Configuration::Style do
     end
 
     it 'returns a Hash of all of the attributes and values' do
-      subject.to_hash.should == default_values
+      expect(subject.to_hash).to eq default_values
     end
 
     context 'with a user-added property' do
@@ -194,7 +193,7 @@ describe Tailor::Configuration::Style do
       end
 
       it 'includes the new property as part of the Hash' do
-        subject.to_hash.should include long_pants: [1, { level: :warn }]
+        expect(subject.to_hash).to include long_pants: [1, { level: :warn }]
       end
     end
   end

--- a/spec/unit/tailor/configuration_spec.rb
+++ b/spec/unit/tailor/configuration_spec.rb
@@ -3,7 +3,7 @@ require 'tailor/configuration'
 require 'tailor/cli'
 
 describe Tailor::Configuration do
-  before { Tailor::Logger.stub(:log) }
+  before { allow(Tailor::Logger).to receive(:log) }
 
   subject do
     Tailor::Configuration.new('.')
@@ -13,14 +13,14 @@ describe Tailor::Configuration do
     context 'param is nil' do
       it 'returns the pre-exisiting @formatters' do
         subject.instance_variable_set(:@formatters, [:blah])
-        subject.formatters.should == [:blah]
+        expect(subject.formatters).to eq [:blah]
       end
     end
 
     context 'param is some value' do
       it 'sets @formatters to that value' do
         subject.formatters 'blah'
-        subject.instance_variable_get(:@formatters).should == ['blah']
+        expect(subject.instance_variable_get(:@formatters)).to eq ['blah']
       end
     end
   end
@@ -35,7 +35,7 @@ describe Tailor::Configuration do
         style.trailing_newlines 2
       end
 
-      subject.instance_variable_get(:@file_sets).should == {
+      expect(subject.instance_variable_get(:@file_sets)).to eq(
         bobo: {
           file_list: [],
           style: {
@@ -65,13 +65,13 @@ describe Tailor::Configuration do
             trailing_newlines: [2, { level: :error }]
           }
         }
-      }
+      )
     end
 
     context 'first param is nil' do
       it 'uses :default as the label' do
         subject.file_set
-        subject.instance_variable_get(:@file_sets).should include(:default)
+        expect(subject.instance_variable_get(:@file_sets)).to include(:default)
       end
     end
   end
@@ -81,14 +81,14 @@ describe Tailor::Configuration do
       it 'returns @config_file' do
         subject.instance_variable_set(:@config_file, 'pants')
         subject.config_file
-        subject.instance_variable_get(:@config_file).should == 'pants'
+        expect(subject.instance_variable_get(:@config_file)).to eq 'pants'
       end
     end
 
     context '@config_file is nil' do
       context 'DEFAULT_PROJECT_CONFIG exists' do
         before do
-          File.should_receive(:exists?).with(/\.tailor/).and_return true
+          expect(File).to receive(:exists?).with(/\.tailor/).and_return true
         end
 
         it "returns Dir.pwd + './tailor'" do
@@ -98,14 +98,14 @@ describe Tailor::Configuration do
 
       context 'DEFAULT_PROJECT_CONFIG does not exist' do
         before do
-          File.should_receive(:exists?).with(/\.tailor/).and_return false
-          File.should_receive(:exists?).with(/\.tailorrc/).and_return true
+          expect(File).to receive(:exists?).with(/\.tailor/).and_return false
+          expect(File).to receive(:exists?).with(/\.tailorrc/).and_return true
         end
 
         it 'returns DEFAULT_RC_FILE' do
           subject.config_file
-          subject.instance_variable_get(:@config_file).should ==
-            Tailor::Configuration::DEFAULT_RC_FILE
+          expect(subject.instance_variable_get(:@config_file)).
+            to eq Tailor::Configuration::DEFAULT_RC_FILE
         end
       end
     end
@@ -115,11 +115,13 @@ describe Tailor::Configuration do
     before do
       subject.instance_variable_set(:@file_sets, {})
     end
+
     it 'yields if a block is provided' do
       expect do |config|
         subject.recursive_file_set('*.rb', &config)
       end.to yield_control
     end
+
     it 'does not raise if a block is not provided' do
       expect { subject.recursive_file_set('*.rb') }.not_to raise_error
     end

--- a/spec/unit/tailor/formatter_spec.rb
+++ b/spec/unit/tailor/formatter_spec.rb
@@ -22,7 +22,7 @@ describe Tailor::Formatter do
 
     context 'problems are empty' do
       it 'returns an empty Array' do
-        subject.problems_at_level({}, :error).should == []
+        expect(subject.problems_at_level({}, :error)).to eq []
       end
     end
 
@@ -31,7 +31,7 @@ describe Tailor::Formatter do
         msg = 'File contains invalid Ruby; '
         msg << 'run `ruby -c [your_file.rb]` for more details.'
 
-        subject.problems_at_level(problems, :warn).should == [
+        expect(subject.problems_at_level(problems, :warn)).to eq [
           {
             type: 'allow_invalid_ruby',
             line: 0,
@@ -45,7 +45,7 @@ describe Tailor::Formatter do
 
     context 'the level asked for does not exist in the problems' do
       it 'returns an empty Array' do
-        subject.problems_at_level(problems, :error).should == []
+        expect(subject.problems_at_level(problems, :error)).to eq []
       end
     end
   end

--- a/spec/unit/tailor/formatters/yaml_spec.rb
+++ b/spec/unit/tailor/formatters/yaml_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'tailor/formatters/yaml'
 require 'yaml'
 
-
 describe Tailor::Formatters::Yaml do
   describe '#summary_report' do
     context 'no files have problems' do
@@ -16,7 +15,7 @@ describe Tailor::Formatters::Yaml do
       it 'returns YAML with no body' do
         result = subject.summary_report(problems)
         hash = YAML.load(result)
-        hash.should == {}
+        expect(hash).to eq({})
       end
     end
 
@@ -34,10 +33,10 @@ describe Tailor::Formatters::Yaml do
       it 'returns YAML that contains the problem file and its problem' do
         result = subject.summary_report(problems)
         hash = YAML.load(result)
-        hash.keys.size.should == 1
-        hash.keys.first.should == '/path_to/file1.rb'
-        hash.should_not include '/path_to/file2.rb'
-        hash['/path_to/file1.rb'].first[:type].should eq 'type1'
+        expect(hash.keys.size).to eq 1
+        expect(hash.keys.first).to eq '/path_to/file1.rb'
+        expect(hash).to_not include '/path_to/file2.rb'
+        expect(hash['/path_to/file1.rb'].first[:type]).to eq 'type1'
       end
     end
 
@@ -62,13 +61,13 @@ describe Tailor::Formatters::Yaml do
       it 'returns YAML that contains the problem files and their problems' do
         result = subject.summary_report(problems)
         hash = YAML.load(result)
-        hash.keys.size.should == 2
-        hash.keys.first.should == '/path_to/file1.rb'
-        hash.keys.last.should == '/path_to/file3.rb'
-        hash.should_not include '/path_to/file2.rb'
-        hash['/path_to/file1.rb'].first[:type].should eq 'type1'
-        hash['/path_to/file3.rb'].first[:type].should eq 'type2'
-        hash['/path_to/file3.rb'].last[:type].should eq 'type3'
+        expect(hash.keys.size).to eq 2
+        expect(hash.keys.first).to eq '/path_to/file1.rb'
+        expect(hash.keys.last).to eq '/path_to/file3.rb'
+        expect(hash).to_not include '/path_to/file2.rb'
+        expect(hash['/path_to/file1.rb'].first[:type]).to eq 'type1'
+        expect(hash['/path_to/file3.rb'].first[:type]).to eq 'type2'
+        expect(hash['/path_to/file3.rb'].last[:type]).to eq 'type3'
       end
     end
   end

--- a/spec/unit/tailor/lexed_line_spec.rb
+++ b/spec/unit/tailor/lexed_line_spec.rb
@@ -44,24 +44,24 @@ describe Tailor::LexedLine do
     context '0 length line, no \n ending' do
       let(:lexed_output) { [[[1, 0], :on_sp, '  ']] }
 
-      it 'should return true' do
-        subject.only_spaces?.should be_true
+      it 'is true' do
+        expect(subject.only_spaces?).to eq true
       end
     end
 
     context '0 length line, with \n ending' do
       let(:lexed_output) { [[[1, 0], :on_nl, "\n"]] }
 
-      it 'should return true' do
-        subject.only_spaces?.should be_true
+      it 'is true' do
+        expect(subject.only_spaces?).to eq true
       end
     end
 
     context 'comment line, starting at column 0' do
       let(:lexed_output) { [[[1, 0], :on_comment, '# comment']] }
 
-      it 'should return false' do
-        subject.only_spaces?.should be_false
+      it 'is false' do
+        expect(subject.only_spaces?).to eq false
       end
     end
 
@@ -73,8 +73,8 @@ describe Tailor::LexedLine do
         ]
       end
 
-      it 'should return false' do
-        subject.only_spaces?.should be_false
+      it 'is false' do
+        expect(subject.only_spaces?).to eq false
       end
     end
 
@@ -90,8 +90,8 @@ describe Tailor::LexedLine do
         ]
       end
 
-      it 'should return false' do
-        subject.only_spaces?.should be_false
+      it 'is false' do
+        expect(subject.only_spaces?).to eq false
       end
     end
   end
@@ -113,7 +113,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns true' do
-        subject.ends_with_op?.should be_true
+        expect(subject.ends_with_op?).to eq true
       end
     end
 
@@ -130,7 +130,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns false' do
-        subject.ends_with_op?.should be_false
+        expect(subject.ends_with_op?).to eq false
       end
     end
   end
@@ -148,10 +148,10 @@ describe Tailor::LexedLine do
         ]
       end
 
-      before { subject.stub(:ends_with_kw?).and_return true }
+      before { allow(subject).to receive(:ends_with_kw?).and_return true }
 
       it 'returns false' do
-        subject.ends_with_modifier_kw?.should be_false
+        expect(subject.ends_with_modifier_kw?).to eq false
       end
     end
 
@@ -173,29 +173,25 @@ describe Tailor::LexedLine do
 
       context 'the keyword is a modifier' do
         before do
-          token.stub(:modifier_keyword?).and_return true
-          Tailor::Lexer::Token.stub(:new).and_return token
-          subject.stub(:ends_with_kw?).and_return true
+          allow(token).to receive(:modifier_keyword?).and_return true
+          allow(Tailor::Lexer::Token).to receive(:new).and_return token
+          allow(subject).to receive(:ends_with_kw?).and_return true
         end
 
-        after { Tailor::Lexer::Token.unstub(:new) }
-
         it 'returns true' do
-          subject.ends_with_modifier_kw?.should be_true
+          expect(subject.ends_with_modifier_kw?).to eq true
         end
       end
 
       context 'the keyword is not a modifier' do
         before do
-          token.stub(:modifier_keyword?).and_return false
-          Tailor::Lexer::Token.stub(:new).and_return token
-          subject.stub(:ends_with_kw?).and_return true
+          allow(token).to receive(:modifier_keyword?).and_return false
+          allow(Tailor::Lexer::Token).to receive(:new).and_return token
+          allow(subject).to receive(:ends_with_kw?).and_return true
         end
 
-        after { Tailor::Lexer::Token.unstub(:new) }
-
-        it 'returns true' do
-          subject.ends_with_modifier_kw?.should be_false
+        it 'returns false' do
+          expect(subject.ends_with_modifier_kw?).to eq false
         end
       end
     end
@@ -214,13 +210,13 @@ describe Tailor::LexedLine do
 
     context 'line ends with the event' do
       it 'returns true' do
-        subject.does_line_end_with(:on_sp).should be_true
+        expect(subject.does_line_end_with(:on_sp)).to eq true
       end
     end
 
     context 'line does not even with event' do
       it 'returns false' do
-        subject.does_line_end_with(:on_kw).should be_false
+        expect(subject.does_line_end_with(:on_kw)).to eq false
       end
     end
   end
@@ -238,7 +234,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns the space' do
-        subject.last_non_line_feed_event.should == [[1, 9], :on_sp, ' ']
+        expect(subject.last_non_line_feed_event).to eq [[1, 9], :on_sp, ' ']
       end
     end
 
@@ -253,7 +249,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns the event before it' do
-        subject.last_non_line_feed_event.should == [[1, 4], :on_ident, 'thing']
+        expect(subject.last_non_line_feed_event).to eq [[1, 4], :on_ident, 'thing']
       end
     end
   end
@@ -272,7 +268,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns true' do
-        subject.loop_with_do?.should be_true
+        expect(subject.loop_with_do?).to eq true
       end
     end
 
@@ -288,7 +284,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns false' do
-        subject.loop_with_do?.should be_false
+        expect(subject.loop_with_do?).to eq false
       end
     end
 
@@ -305,7 +301,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns true' do
-        subject.loop_with_do?.should be_true
+        expect(subject.loop_with_do?).to eq true
       end
     end
 
@@ -321,7 +317,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns false' do
-        subject.loop_with_do?.should be_false
+        expect(subject.loop_with_do?).to eq false
       end
     end
 
@@ -344,7 +340,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns true' do
-        subject.loop_with_do?.should be_true
+        expect(subject.loop_with_do?).to eq true
       end
     end
 
@@ -366,7 +362,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns false' do
-        subject.loop_with_do?.should be_false
+        expect(subject.loop_with_do?).to eq false
       end
     end
   end
@@ -376,7 +372,7 @@ describe Tailor::LexedLine do
       let(:lexed_output) { [[[1, 0], :on_sp, '     ']] }
 
       it 'returns nil' do
-        subject.first_non_space_element.should be_nil
+        expect(subject.first_non_space_element).to be_nil
       end
     end
 
@@ -384,7 +380,7 @@ describe Tailor::LexedLine do
       let(:lexed_output) { [[[1, 0], :on_ignored_nl, "\n"]] }
 
       it 'returns nil' do
-        subject.first_non_space_element.should be_nil
+        expect(subject.first_non_space_element).to be_nil
       end
     end
 
@@ -397,8 +393,8 @@ describe Tailor::LexedLine do
         ]
       end
 
-      it 'returns nil' do
-        subject.first_non_space_element.should == [[1, 2], :on_rbrace, '}']
+      it 'returns the token array' do
+        expect(subject.first_non_space_element).to eq [[1, 2], :on_rbrace, '}']
       end
     end
   end
@@ -408,13 +404,13 @@ describe Tailor::LexedLine do
 
     context 'self contains an event at the given column' do
       it 'returns that event' do
-        subject.event_at(0).should == lexed_output.first
+        expect(subject.event_at(0)).to eq lexed_output.first
       end
     end
 
     context 'self does not contain an event at the given column' do
       it 'returns nil' do
-        subject.event_at(1234).should be_nil
+        expect(subject.event_at(1234)).to be_nil
       end
     end
   end
@@ -423,13 +419,13 @@ describe Tailor::LexedLine do
     let(:lexed_output) { [[[1, 0], :on_sp, '     ']] }
 
     context '#event_at returns nil' do
-      before { subject.stub(:event_at).and_return nil }
-      specify { subject.event_index(1234).should be_nil }
+      before { allow(subject).to receive(:event_at).and_return nil }
+      specify { expect(subject.event_index(1234)).to be_nil }
     end
 
     context '#event_at returns a valid column' do
       it 'returns the event' do
-        subject.event_index(0).should be_zero
+        expect(subject.event_index(0)).to be_zero
       end
     end
   end
@@ -446,7 +442,7 @@ describe Tailor::LexedLine do
     end
 
     it "returns the String made up of self's tokens" do
-      subject.to_s.should == "def thing \n"
+      expect(subject.to_s).to eq "def thing \n"
     end
   end
 
@@ -471,7 +467,7 @@ describe Tailor::LexedLine do
         end
 
         it 'replaces the comment with an :on_ignored_nl' do
-          subject.remove_trailing_comment(file_text).should == [
+          expect(subject.remove_trailing_comment(file_text)).to eq [
             [[1, 0], :on_kw, 'def'],
             [[1, 3], :on_sp, ' '],
             [[1, 4], :on_ident, 'thing'],
@@ -501,7 +497,7 @@ describe Tailor::LexedLine do
         end
 
         it 'replaces the comment with an :on_ignored_nl' do
-          subject.remove_trailing_comment(file_text).should == [
+          expect(subject.remove_trailing_comment(file_text)).to eq [
             [[1, 0], :on_kw, 'def'],
             [[1, 3], :on_sp, ' '],
             [[1, 4], :on_ident, 'thing'],
@@ -533,7 +529,7 @@ describe Tailor::LexedLine do
         end
 
         it 'replaces the comment with an :on_nl' do
-          subject.remove_trailing_comment(file_text).should == [
+          expect(subject.remove_trailing_comment(file_text)).to eq [
             [[1, 0], :on_kw, 'def'],
             [[1, 3], :on_sp, ' '],
             [[1, 4], :on_ident, 'thing'],
@@ -561,7 +557,7 @@ describe Tailor::LexedLine do
         end
 
         it 'replaces the comment with an :on_nl' do
-          subject.remove_trailing_comment(file_text).should == [
+          expect(subject.remove_trailing_comment(file_text)).to eq [
             [[1, 0], :on_kw, 'def'],
             [[1, 3], :on_sp, ' '],
             [[1, 4], :on_ident, 'thing'],
@@ -572,8 +568,8 @@ describe Tailor::LexedLine do
         end
 
         it 'returns a LexedLine' do
-          subject.remove_trailing_comment(file_text).
-            should be_a Tailor::LexedLine
+          expect(subject.remove_trailing_comment(file_text)).
+            to be_a Tailor::LexedLine
         end
       end
     end
@@ -586,7 +582,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns true' do
-        subject.end_of_multi_line_string?.should be_true
+        expect(subject.end_of_multi_line_string?).to eq true
       end
     end
 
@@ -595,8 +591,8 @@ describe Tailor::LexedLine do
         [[[1, 11], :on_comma, ','], [[1, 12], :on_nl, "\n"]]
       end
 
-      it 'returns true' do
-        subject.end_of_multi_line_string?.should be_false
+      it 'returns false' do
+        expect(subject.end_of_multi_line_string?).to eq false
       end
     end
 
@@ -609,8 +605,8 @@ describe Tailor::LexedLine do
         ]
       end
 
-      it 'returns true' do
-        subject.end_of_multi_line_string?.should be_false
+      it 'returns false' do
+        expect(subject.end_of_multi_line_string?).to eq false
       end
     end
   end
@@ -626,10 +622,11 @@ describe Tailor::LexedLine do
       end
 
       before do
-        subject.stub(:last_non_line_feed_event).and_return last_event
+        allow(subject).to receive(:last_non_line_feed_event).
+          and_return last_event
       end
 
-      specify { subject.is_line_only_a(:on_period).should be_false }
+      specify { expect(subject.is_line_only_a(:on_period)).to eq false }
     end
 
     context 'last event is the last event passed in' do
@@ -641,7 +638,7 @@ describe Tailor::LexedLine do
             [[1, 12], :on_nl, "\n"]]
         end
 
-        specify { subject.is_line_only_a(:on_comma).should be_true }
+        specify { expect(subject.is_line_only_a(:on_comma)).to eq true }
       end
 
       context 'there is non-spaces before the last event' do
@@ -653,7 +650,7 @@ describe Tailor::LexedLine do
             [[1, 12], :on_nl, "\n"]]
         end
 
-        specify { subject.is_line_only_a(:on_comma).should be_false }
+        specify { expect(subject.is_line_only_a(:on_comma)).to eq false }
       end
     end
   end
@@ -669,7 +666,7 @@ describe Tailor::LexedLine do
       end
 
       it 'returns false' do
-        subject.keyword_is_symbol?.should be_false
+        expect(subject.keyword_is_symbol?).to eq false
       end
     end
 
@@ -682,7 +679,7 @@ describe Tailor::LexedLine do
         end
 
         it 'returns false' do
-          subject.keyword_is_symbol?.should be_false
+          expect(subject.keyword_is_symbol?).to eq false
         end
       end
 
@@ -695,7 +692,7 @@ describe Tailor::LexedLine do
         end
 
         it 'returns false' do
-          subject.keyword_is_symbol?.should be_false
+          expect(subject.keyword_is_symbol?).to eq false
         end
       end
 
@@ -709,7 +706,7 @@ describe Tailor::LexedLine do
         end
 
         it 'returns true' do
-          subject.keyword_is_symbol?.should be_true
+          expect(subject.keyword_is_symbol?).to eq true
         end
       end
     end

--- a/spec/unit/tailor/lexed_line_spec.rb
+++ b/spec/unit/tailor/lexed_line_spec.rb
@@ -3,7 +3,7 @@ require 'tailor/lexed_line'
 
 describe Tailor::LexedLine do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
   end
 
   subject { Tailor::LexedLine.new(lexed_output, 1) }
@@ -29,7 +29,7 @@ describe Tailor::LexedLine do
     it 'returns all lexed output from line 1 when self.lineno is 1' do
       line = Tailor::LexedLine.new(lexed_output, 1)
 
-      line.should == [
+      expect(line).to eq [
         [[1, 0], :on_ident, 'require'],
         [[1, 7], :on_sp, ' '],
         [[1, 8], :on_tstring_beg, "'"],
@@ -249,7 +249,8 @@ describe Tailor::LexedLine do
       end
 
       it 'returns the event before it' do
-        expect(subject.last_non_line_feed_event).to eq [[1, 4], :on_ident, 'thing']
+        expect(subject.last_non_line_feed_event).
+          to eq [[1, 4], :on_ident, 'thing']
       end
     end
   end
@@ -376,7 +377,7 @@ describe Tailor::LexedLine do
       end
     end
 
-    context "lexed line contains only \\n" do
+    context 'lexed line contains only \n' do
       let(:lexed_output) { [[[1, 0], :on_ignored_nl, "\n"]] }
 
       it 'returns nil' do

--- a/spec/unit/tailor/lexer/token_spec.rb
+++ b/spec/unit/tailor/lexer/token_spec.rb
@@ -3,7 +3,7 @@ require 'tailor/lexer/token'
 
 describe Tailor::Lexer::Token do
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
   end
 
   describe '#modifier_keyword?' do
@@ -17,7 +17,7 @@ describe Tailor::Lexer::Token do
         let!(:full_line_of_text) { %q{puts "hi" if true == true} }
 
         it 'returns true' do
-          subject.modifier_keyword?.should be_true
+          expect(subject.modifier_keyword?).to eq true
         end
       end
 
@@ -25,7 +25,7 @@ describe Tailor::Lexer::Token do
         let!(:full_line_of_text) { %q{if true == true; puts "hi"; end} }
 
         it 'returns false' do
-          subject.modifier_keyword?.should be_false
+          expect(subject.modifier_keyword?).to eq false
         end
       end
     end
@@ -39,7 +39,7 @@ describe Tailor::Lexer::Token do
       end
 
       it 'returns false' do
-        subject.modifier_keyword?.should be_false
+        expect(subject.modifier_keyword?).to eq false
       end
     end
   end

--- a/spec/unit/tailor/lexer/token_spec.rb
+++ b/spec/unit/tailor/lexer/token_spec.rb
@@ -14,7 +14,7 @@ describe Tailor::Lexer::Token do
 
     context 'the current line has a keyword that is also a modifier' do
       context 'the keyword is acting as a modifier' do
-        let!(:full_line_of_text) { %q{puts "hi" if true == true} }
+        let!(:full_line_of_text) { %(puts "hi" if true == true) }
 
         it 'returns true' do
           expect(subject.modifier_keyword?).to eq true
@@ -22,7 +22,7 @@ describe Tailor::Lexer::Token do
       end
 
       context 'they keyword is NOT acting as a modifier' do
-        let!(:full_line_of_text) { %q{if true == true; puts "hi"; end} }
+        let!(:full_line_of_text) { %(if true == true; puts "hi"; end) }
 
         it 'returns false' do
           expect(subject.modifier_keyword?).to eq false
@@ -31,7 +31,7 @@ describe Tailor::Lexer::Token do
     end
 
     context 'the current line does not have a keyword' do
-      let!(:full_line_of_text) { %q{puts true} }
+      let!(:full_line_of_text) { %(puts true) }
 
       subject do
         options = { full_line_of_text: full_line_of_text }

--- a/spec/unit/tailor/lexer_spec.rb
+++ b/spec/unit/tailor/lexer_spec.rb
@@ -9,13 +9,13 @@ describe Tailor::Lexer do
   subject do
     r = Tailor::Lexer.new(file_text)
     r.instance_variable_set(:@buf, [])
-    r.stub(:log)
+    allow(r).to receive(:log)
 
     r
   end
 
   before do
-    Tailor::Lexer.any_instance.stub(:ensure_trailing_newline).
+    allow_any_instance_of(Tailor::Lexer).to receive(:ensure_trailing_newline).
       and_return(file_text)
   end
 
@@ -29,8 +29,8 @@ describe Tailor::Lexer do
 
       it 'opens and reads the file by the name passed in' do
         file = double 'File'
-        file.should_receive(:read).and_return file_text
-        File.should_receive(:open).with('test', 'r').and_return file
+        expect(file).to receive(:read).and_return file_text
+        expect(File).to receive(:open).with('test', 'r').and_return file
         Tailor::Lexer.new(file_name)
       end
     end
@@ -39,7 +39,7 @@ describe Tailor::Lexer do
       let(:text) { 'some text' }
 
       it 'does not try to open a file' do
-        File.should_not_receive(:open)
+        expect(File).to_not receive(:open)
         Tailor::Lexer.new(text)
       end
     end
@@ -48,7 +48,7 @@ describe Tailor::Lexer do
   describe '#on_sp' do
     context 'token is a backslash then newline' do
       it 'calls #notify_ignored_nl_observers' do
-        subject.should_receive(:notify_ignored_nl_observers)
+        expect(subject).to receive(:notify_ignored_nl_observers)
         subject.on_sp("\\\n")
       end
     end
@@ -57,43 +57,43 @@ describe Tailor::Lexer do
   describe '#current_line_of_text' do
     before do
       subject.instance_variable_set(:@file_text, file_text)
-      subject.stub(:lineno).and_return 1
+      allow(subject).to receive(:lineno).and_return 1
     end
 
-    context "@file_text is 1 line with 0 \\ns" do
+    context '@file_text is 1 line with 0 \ns' do
       let(:file_text) { "puts 'code'" }
 
       it 'returns the line' do
-        subject.current_line_of_text.should == file_text
+        expect(subject.current_line_of_text).to eq file_text
       end
     end
 
-    context "@file_text is 1 empty line with 0 \\ns" do
+    context '@file_text is 1 empty line with 0 \ns' do
       let(:file_text) { '' }
 
       it 'returns the an empty string' do
-        subject.current_line_of_text.should == file_text
+        expect(subject.current_line_of_text).to eq file_text
       end
     end
 
-    context "@file_text is 1 empty line with 1 \\n" do
+    context '@file_text is 1 empty line with 1 \n' do
       let(:file_text) { "\n" }
 
       it 'returns an empty string' do
-        subject.current_line_of_text.should == ''
+        expect(subject.current_line_of_text).to eq ''
       end
     end
   end
 
   describe '#count_trailing_newlines' do
-    context "text contains 0 trailing \\n" do
+    context 'text contains 0 trailing \n' do
       let(:text) { 'text' }
-      specify { subject.count_trailing_newlines(text).should be_zero }
+      specify { expect(subject.count_trailing_newlines(text)).to be_zero }
     end
 
-    context "text contains 1 trailing \\n" do
+    context 'text contains 1 trailing \n' do
       let(:text) { "text\n" }
-      specify { subject.count_trailing_newlines(text).should == 1 }
+      specify { expect(subject.count_trailing_newlines(text)).to eq 1 }
     end
   end
 
@@ -106,11 +106,11 @@ describe Tailor::Lexer do
       let!(:text) { "text\n" }
 
       before do
-        subject.stub(:count_trailing_newlines).and_return 1
+        allow(subject).to receive(:count_trailing_newlines).and_return 1
       end
 
       it 'does not alter the text' do
-        subject.ensure_trailing_newline(text).should == text
+        expect(subject.ensure_trailing_newline(text)).to eq text
       end
     end
 
@@ -118,15 +118,15 @@ describe Tailor::Lexer do
       let!(:text) { 'text' }
 
       it 'adds a newline at the end' do
-        subject.ensure_trailing_newline(text).should == text + "\n"
+        expect(subject.ensure_trailing_newline(text)).to eq(text + "\n")
       end
     end
   end
 
   describe '#sub_line_ending_backslashes' do
     let!(:text) do
-      %Q{command \\
-  'something'}
+      %(command \\
+  'something')
     end
 
     before do
@@ -136,8 +136,8 @@ describe Tailor::Lexer do
     end
 
     it 'replaces all line-ending backslashes with a comment' do
-      subject.sub_publicly(text).should == %Q{command # TAILOR REMOVED BACKSLASH
-  'something'}
+      expect(subject.sub_publicly(text)).to eq %(command # TAILOR REMOVED BACKSLASH
+  'something')
     end
   end
 end

--- a/spec/unit/tailor/problem_spec.rb
+++ b/spec/unit/tailor/problem_spec.rb
@@ -3,7 +3,7 @@ require 'tailor/problem'
 
 describe Tailor::Problem do
   before do
-    Tailor::Problem.any_instance.stub(:log)
+    allow_any_instance_of(Tailor::Problem).to receive(:log)
   end
 
   let(:lineno) { 10 }
@@ -11,32 +11,32 @@ describe Tailor::Problem do
 
   describe '#set_values' do
     before do
-      Tailor::Problem.any_instance.stub(:message)
+      allow_any_instance_of(Tailor::Problem).to receive(:message)
     end
 
     it 'sets self[:type] to the type param' do
-      Tailor::Problem.new(:test, lineno, column, '', :b).
-        should include(type: :test)
+      expect(Tailor::Problem.new(:test, lineno, column, '', :b)).
+        to include(type: :test)
     end
 
     it 'sets self[:line] to the lineno param' do
-      Tailor::Problem.new(:test, lineno, column, '', :c).
-        should include(line: lineno)
+      expect(Tailor::Problem.new(:test, lineno, column, '', :c)).
+        to include(line: lineno)
     end
 
     it 'sets self[:column] to the column param' do
-      Tailor::Problem.new(:test, lineno, column, '', :d).
-        should include(column: column)
+      expect(Tailor::Problem.new(:test, lineno, column, '', :d)).
+        to include(column: column)
     end
 
     it 'sets self[:message] to the message param' do
-      Tailor::Problem.new(:test, lineno, column, 'test', :d).
-        should include(message: 'test')
+      expect(Tailor::Problem.new(:test, lineno, column, 'test', :d)).
+        to include(message: 'test')
     end
 
     it 'sets self[:level] to the level param' do
-      Tailor::Problem.new(:test, lineno, column, 'test', :d).
-        should include(level: :d)
+      expect(Tailor::Problem.new(:test, lineno, column, 'test', :d)).
+        to include(level: :d)
     end
   end
 end

--- a/spec/unit/tailor/reporter_spec.rb
+++ b/spec/unit/tailor/reporter_spec.rb
@@ -8,7 +8,7 @@ describe Tailor::Reporter do
 
       it 'creates a new Formatter object of the type passed in' do
         reporter = Tailor::Reporter.new(formats)
-        reporter.formatters.first.should be_a Tailor::Formatters::Text
+        expect(reporter.formatters.first).to be_a Tailor::Formatters::Text
       end
     end
   end
@@ -26,7 +26,7 @@ describe Tailor::Reporter do
 
     it 'calls #file_report on each @formatters' do
       label = :some_label
-      formatter.should_receive(:file_report).with(file_problems, label)
+      expect(formatter).to receive(:file_report).with(file_problems, label)
 
       subject.file_report(file_problems, label)
     end
@@ -45,8 +45,8 @@ describe Tailor::Reporter do
 
     context 'without output file' do
       it 'calls #file_report on each @formatters' do
-        formatter.should_receive(:summary_report).with(all_problems)
-        File.should_not_receive(:open)
+        expect(formatter).to receive(:summary_report).with(all_problems)
+        expect(File).to_not receive(:open)
 
         subject.summary_report(all_problems)
       end
@@ -55,18 +55,17 @@ describe Tailor::Reporter do
     context 'with output file' do
       let(:output_file) { 'output.whatever' }
       before do
-        formatter.should_receive(:respond_to?).with(:accepts_output_file).
+        expect(formatter).to receive(:respond_to?).with(:accepts_output_file).
           and_return(true)
-        formatter.should_receive(:accepts_output_file).and_return(true)
+        expect(formatter).to receive(:accepts_output_file).and_return(true)
       end
 
       it 'calls #summary_report on each @formatters' do
-        formatter.should_receive(:summary_report).with(all_problems)
-        File.should_receive(:open).with(output_file, 'w')
+        expect(formatter).to receive(:summary_report).with(all_problems)
+        expect(File).to receive(:open).with(output_file, 'w')
 
         subject.summary_report(all_problems, output_file: output_file)
       end
     end
-
   end
 end

--- a/spec/unit/tailor/ruler_spec.rb
+++ b/spec/unit/tailor/ruler_spec.rb
@@ -2,54 +2,54 @@ require 'spec_helper'
 require 'tailor/ruler'
 
 describe Tailor::Ruler do
-  before { Tailor::Logger.stub(:log) }
+  before { allow(Tailor::Logger).to receive(:log) }
 
   describe '#add_child_ruler' do
     it 'adds new rulers to @child_rulers' do
       ruler = double 'Ruler'
       subject.add_child_ruler(ruler)
-      subject.instance_variable_get(:@child_rulers).first.should == ruler
+      expect(subject.instance_variable_get(:@child_rulers).first).to eq ruler
     end
   end
 
   describe '#problems' do
     context 'no child_rulers' do
       context '@problems is empty' do
-        specify { subject.problems.should be_empty }
+        specify { expect(subject.problems).to be_empty }
       end
 
       context '@problems.size is 1' do
         before do
           problem = double 'Problem'
-          problem.should_receive(:[]).with :line
+          expect(problem).to receive(:[]).with :line
           subject.instance_variable_set(:@problems, [problem])
         end
 
-        specify { subject.problems.size.should == 1 }
+        specify { expect(subject.problems.size).to eq 1 }
       end
     end
 
     context 'child_rulers have problems' do
       before do
         problem = double 'Problem'
-        problem.should_receive(:[]).with :line
+        expect(problem).to receive(:[]).with :line
         child_ruler = double 'Ruler'
-        child_ruler.stub(:problems).and_return([problem])
+        allow(child_ruler).to receive(:problems).and_return([problem])
         subject.instance_variable_set(:@child_rulers, [child_ruler])
       end
 
       context '@problems is empty' do
-        specify { subject.problems.size.should == 1 }
+        specify { expect(subject.problems.size).to eq 1 }
       end
 
       context '@problems.size is 1' do
         before do
           problem = double 'Problem'
-          problem.should_receive(:[]).with :line
+          expect(problem).to receive(:[]).with :line
           subject.instance_variable_set(:@problems, [problem])
         end
 
-        specify { subject.problems.size.should == 2 }
+        specify { expect(subject.problems.size).to eq 2 }
       end
     end
   end

--- a/spec/unit/tailor/rulers/indentation_spaces_ruler/indentation_manager_spec.rb
+++ b/spec/unit/tailor/rulers/indentation_spaces_ruler/indentation_manager_spec.rb
@@ -2,7 +2,6 @@ require 'ripper'
 require 'spec_helper'
 require 'tailor/rulers/indentation_spaces_ruler/indentation_manager'
 
-
 describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
   let!(:spaces) { 5 }
   let!(:lexed_line) { double 'LexedLine' }
@@ -18,7 +17,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
 
   describe '#should_be_at' do
     it 'returns @proper[:this_line]' do
-      subject.instance_variable_set(:@proper, { this_line: 321 })
+      subject.instance_variable_set(:@proper, this_line: 321)
       expect(subject.should_be_at).to eq 321
     end
   end
@@ -31,9 +30,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
 
       context '@proper[:this_line] gets decremented < 0' do
         it 'sets @proper[:this_line] to 0' do
-          subject.instance_variable_set(:@proper, {
-            this_line: 0, next_line: 0
-          })
+          subject.instance_variable_set(:@proper, this_line: 0, next_line: 0)
 
           subject.decrease_this_line
           proper_indentation = subject.instance_variable_get(:@proper)
@@ -43,9 +40,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
 
       context '@proper[:this_line] NOT decremented < 0' do
         it 'decrements @proper[:this_line] by @spaces' do
-          subject.instance_variable_set(:@proper, {
-            this_line: 28, next_line: 28
-          })
+          subject.instance_variable_set(:@proper, this_line: 28, next_line: 28)
           subject.decrease_this_line
 
           proper_indentation = subject.instance_variable_get(:@proper)
@@ -58,9 +53,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
       before { allow(subject).to receive(:started?).and_return false }
 
       it 'does not decrement @proper[:this_line]' do
-        subject.instance_variable_set(:@proper, {
-          this_line: 28, next_line: 28
-        })
+        subject.instance_variable_set(:@proper, this_line: 28, next_line: 28)
         subject.decrease_this_line
 
         proper_indentation = subject.instance_variable_get(:@proper)
@@ -74,9 +67,9 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
       before { allow(subject).to receive(:started?).and_return true }
 
       it 'sets @proper[:this_line] to @proper[:next_line]' do
-        subject.instance_variable_set(:@proper, { next_line: 33 })
+        subject.instance_variable_set(:@proper, next_line: 33)
 
-        expect { subject.transition_lines }.to change{ subject.should_be_at }.
+        expect { subject.transition_lines }.to change { subject.should_be_at }.
           from(subject.should_be_at).to(33)
       end
     end
@@ -85,8 +78,9 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
       before { allow(subject).to receive(:started?).and_return false }
 
       it 'sets @proper[:this_line] to @proper[:next_line]' do
-        subject.instance_variable_set(:@proper, { next_line: 33 })
-        expect { subject.transition_lines }.to_not change{ subject.should_be_at }
+        subject.instance_variable_set(:@proper, next_line: 33)
+        expect { subject.transition_lines }.
+          to_not change { subject.should_be_at }
       end
     end
   end

--- a/spec/unit/tailor/rulers/indentation_spaces_ruler/indentation_manager_spec.rb
+++ b/spec/unit/tailor/rulers/indentation_spaces_ruler/indentation_manager_spec.rb
@@ -8,7 +8,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
   let!(:lexed_line) { double 'LexedLine' }
 
   before do
-    Tailor::Logger.stub(:log)
+    allow(Tailor::Logger).to receive(:log)
     subject.instance_variable_set(:@spaces, spaces)
   end
 
@@ -19,7 +19,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
   describe '#should_be_at' do
     it 'returns @proper[:this_line]' do
       subject.instance_variable_set(:@proper, { this_line: 321 })
-      subject.should_be_at.should == 321
+      expect(subject.should_be_at).to eq 321
     end
   end
 
@@ -27,7 +27,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
     let!(:spaces) { 27 }
 
     context '#started? is true' do
-      before { subject.stub(:started?).and_return true }
+      before { allow(subject).to receive(:started?).and_return true }
 
       context '@proper[:this_line] gets decremented < 0' do
         it 'sets @proper[:this_line] to 0' do
@@ -37,7 +37,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
 
           subject.decrease_this_line
           proper_indentation = subject.instance_variable_get(:@proper)
-          proper_indentation[:this_line].should == 0
+          expect(proper_indentation[:this_line]).to be_zero
         end
       end
 
@@ -49,13 +49,13 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
           subject.decrease_this_line
 
           proper_indentation = subject.instance_variable_get(:@proper)
-          proper_indentation[:this_line].should == 1
+          expect(proper_indentation[:this_line]).to eq 1
         end
       end
     end
 
     context '#started? is false' do
-      before { subject.stub(:started?).and_return false }
+      before { allow(subject).to receive(:started?).and_return false }
 
       it 'does not decrement @proper[:this_line]' do
         subject.instance_variable_set(:@proper, {
@@ -64,29 +64,29 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
         subject.decrease_this_line
 
         proper_indentation = subject.instance_variable_get(:@proper)
-        proper_indentation[:this_line].should == 28
+        expect(proper_indentation[:this_line]).to eq 28
       end
     end
   end
 
   describe '#transition_lines' do
     context '#started? is true' do
-      before { subject.stub(:started?).and_return true }
+      before { allow(subject).to receive(:started?).and_return true }
 
       it 'sets @proper[:this_line] to @proper[:next_line]' do
         subject.instance_variable_set(:@proper, { next_line: 33 })
 
-        expect { subject.transition_lines }.to change{subject.should_be_at}.
+        expect { subject.transition_lines }.to change{ subject.should_be_at }.
           from(subject.should_be_at).to(33)
       end
     end
 
     context '#started? is false' do
-      before { subject.stub(:started?).and_return false }
+      before { allow(subject).to receive(:started?).and_return false }
 
       it 'sets @proper[:this_line] to @proper[:next_line]' do
         subject.instance_variable_set(:@proper, { next_line: 33 })
-        expect { subject.transition_lines }.to_not change{subject.should_be_at}
+        expect { subject.transition_lines }.to_not change{ subject.should_be_at }
       end
     end
   end
@@ -95,7 +95,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
     it 'sets @do_measurement to true' do
       subject.instance_variable_set(:@do_measurement, false)
       subject.start
-      subject.instance_variable_get(:@do_measurement).should be_true
+      expect(subject.instance_variable_get(:@do_measurement)).to eq true
     end
   end
 
@@ -103,38 +103,39 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
     it 'sets @do_measurement to false' do
       subject.instance_variable_set(:@do_measurement, true)
       subject.stop
-      subject.instance_variable_get(:@do_measurement).should be_false
+      expect(subject.instance_variable_get(:@do_measurement)).to eq false
     end
   end
 
   describe '#started?' do
     context '@do_measurement is true' do
       before { subject.instance_variable_set(:@do_measurement, true) }
-      specify { subject.started?.should be_true }
+      specify { expect(subject).to be_started }
     end
 
     context '@do_measurement is false' do
       before { subject.instance_variable_set(:@do_measurement, false) }
-      specify { subject.started?.should be_false }
+      specify { expect(subject).to_not be_started }
     end
   end
 
   describe '#update_actual_indentation' do
     context 'lexed_line_output.end_of_multi_line_string? is true' do
       before do
-        lexed_line.stub(:end_of_multi_line_string?).and_return true
+        allow(lexed_line).to receive(:end_of_multi_line_string?).and_return true
       end
 
       it 'returns without updating @actual_indentation' do
-        lexed_line.should_not_receive(:first_non_space_element)
+        expect(lexed_line).to_not receive(:first_non_space_element)
         subject.update_actual_indentation(lexed_line)
       end
     end
 
     context 'lexed_line_output.end_of_multi_line_string? is false' do
       before do
-        lexed_line.stub(:end_of_multi_line_string?).and_return false
-        lexed_line.stub(:first_non_space_element).
+        allow(lexed_line).to receive(:end_of_multi_line_string?).
+          and_return false
+        allow(lexed_line).to receive(:first_non_space_element).
           and_return first_non_space_element
       end
 
@@ -145,7 +146,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
 
         it 'returns the column value of that element' do
           subject.update_actual_indentation(lexed_line)
-          subject.instance_variable_get(:@actual_indentation).should == 5
+          expect(subject.instance_variable_get(:@actual_indentation)).to eq 5
         end
       end
 
@@ -156,7 +157,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
 
         it 'returns the column value of that element' do
           subject.update_actual_indentation(lexed_line)
-          subject.instance_variable_get(:@actual_indentation).should == 0
+          expect(subject.instance_variable_get(:@actual_indentation)).to be_zero
         end
       end
     end
@@ -165,86 +166,91 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
   describe '#line_ends_with_single_token_indenter?' do
     context 'lexed_line does not end with an op, comma, period, label, or kw' do
       before do
-        lexed_line.stub(ends_with_op?: false)
-        lexed_line.stub(ends_with_comma?: false)
-        lexed_line.stub(ends_with_period?: false)
-        lexed_line.stub(ends_with_label?: false)
-        lexed_line.stub(ends_with_modifier_kw?: false)
+        allow(lexed_line).to receive(:ends_with_op?).and_return false
+        allow(lexed_line).to receive(:ends_with_comma?).and_return false
+        allow(lexed_line).to receive(:ends_with_period?).and_return false
+        allow(lexed_line).to receive(:ends_with_label?).and_return false
+        allow(lexed_line).to receive(:ends_with_modifier_kw?).and_return false
       end
 
       specify do
-        subject.line_ends_with_single_token_indenter?(lexed_line).
-          should be_false
+        expect(subject.line_ends_with_single_token_indenter?(lexed_line)).
+          to eq false
       end
     end
 
     context 'lexed_line ends with an op' do
       before do
-        lexed_line.stub(ends_with_op?: true)
-        lexed_line.stub(ends_with_comma?: false)
-        lexed_line.stub(ends_with_period?: false)
-        lexed_line.stub(ends_with_label?: false)
-        lexed_line.stub(ends_with_modifier_kw?: false)
+        allow(lexed_line).to receive(:ends_with_op?).and_return true
+        allow(lexed_line).to receive(:ends_with_comma?).and_return false
+        allow(lexed_line).to receive(:ends_with_period?).and_return false
+        allow(lexed_line).to receive(:ends_with_label?).and_return false
+        allow(lexed_line).to receive(:ends_with_modifier_kw?).and_return false
       end
 
       specify do
-        subject.line_ends_with_single_token_indenter?(lexed_line).should be_true
+        expect(subject.line_ends_with_single_token_indenter?(lexed_line)).
+          to eq true
       end
     end
 
     context 'lexed_line ends with a comma' do
       before do
-        lexed_line.stub(ends_with_op?: false)
-        lexed_line.stub(ends_with_comma?: true)
-        lexed_line.stub(ends_with_period?: false)
-        lexed_line.stub(ends_with_label?: false)
-        lexed_line.stub(ends_with_modifier_kw?: false)
+        allow(lexed_line).to receive(:ends_with_op?).and_return false
+        allow(lexed_line).to receive(:ends_with_comma?).and_return true
+        allow(lexed_line).to receive(:ends_with_period?).and_return false
+        allow(lexed_line).to receive(:ends_with_label?).and_return false
+        allow(lexed_line).to receive(:ends_with_modifier_kw?).and_return false
       end
 
       specify do
-        subject.line_ends_with_single_token_indenter?(lexed_line).should be_true
+        expect(subject.line_ends_with_single_token_indenter?(lexed_line)).
+          to eq true
       end
     end
 
     context 'lexed_line ends with a period' do
       before do
-        lexed_line.stub(ends_with_op?: false)
-        lexed_line.stub(ends_with_comma?: false)
-        lexed_line.stub(ends_with_period?: true)
-        lexed_line.stub(ends_with_label?: false)
-        lexed_line.stub(ends_with_modifier_kw?: false)
+        allow(lexed_line).to receive(:ends_with_op?).and_return false
+        allow(lexed_line).to receive(:ends_with_comma?).and_return false
+        allow(lexed_line).to receive(:ends_with_period?).and_return true
+        allow(lexed_line).to receive(:ends_with_label?).and_return false
+        allow(lexed_line).to receive(:ends_with_modifier_kw?).and_return false
       end
 
       specify do
-        subject.line_ends_with_single_token_indenter?(lexed_line).should be_true
+        expect(subject.line_ends_with_single_token_indenter?(lexed_line)).
+          to eq true
       end
     end
 
     context 'lexed_line ends with a label' do
       before do
-        lexed_line.stub(ends_with_op?: false)
-        lexed_line.stub(ends_with_comma?: false)
-        lexed_line.stub(ends_with_period?: false)
-        lexed_line.stub(ends_with_label?: true)
-        lexed_line.stub(ends_with_modifier_kw?: false)
+        allow(lexed_line).to receive(:ends_with_op?).and_return false
+        allow(lexed_line).to receive(:ends_with_comma?).and_return false
+        allow(lexed_line).to receive(:ends_with_period?).and_return false
+        allow(lexed_line).to receive(:ends_with_label?).and_return true
+        allow(lexed_line).to receive(:ends_with_modifier_kw?).and_return false
       end
 
       specify do
-        subject.line_ends_with_single_token_indenter?(lexed_line).should be_true
+        expect(subject.line_ends_with_single_token_indenter?(lexed_line)).
+          to eq true
       end
     end
 
     context 'lexed_line ends with a modified kw' do
       before do
-        lexed_line.stub(ends_with_op?: false)
-        lexed_line.stub(ends_with_comma?: false)
-        lexed_line.stub(ends_with_period?: false)
-        lexed_line.stub(ends_with_label?: false)
-        lexed_line.stub(ends_with_modifier_kw?: true)
+        allow(lexed_line).to receive(:ends_with_op?).and_return false
+        allow(lexed_line).to receive(:ends_with_comma?).and_return false
+        allow(lexed_line).to receive(:ends_with_period?).and_return false
+        allow(lexed_line).to receive(:ends_with_label?).and_return false
+        allow(lexed_line).to receive(:ends_with_modifier_kw?).and_return true
       end
 
       specify do
-        subject.line_ends_with_single_token_indenter?(lexed_line).should be_true
+        expect(subject.line_ends_with_single_token_indenter?(lexed_line)).
+          to eq true
       end
     end
   end
@@ -256,7 +262,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
       end
 
       it 'returns false' do
-        subject.line_ends_with_same_as_last([]).should be_false
+        expect(subject.line_ends_with_same_as_last([])).to eq false
       end
     end
 
@@ -269,7 +275,8 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
       end
 
       it 'returns false' do
-        subject.line_ends_with_same_as_last(last_single_token).should be_false
+        expect(subject.line_ends_with_same_as_last(last_single_token)).
+          to eq false
       end
     end
 
@@ -282,7 +289,8 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
       end
 
       it 'returns true' do
-        subject.line_ends_with_same_as_last(last_single_token).should be_true
+        expect(subject.line_ends_with_same_as_last(last_single_token)).
+          to eq true
       end
     end
   end
@@ -296,7 +304,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
         end
 
         it 'returns true' do
-          subject.multi_line_parens?(2).should be_true
+          expect(subject.multi_line_parens?(2)).to eq true
         end
       end
 
@@ -306,8 +314,8 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
           subject.instance_variable_set(:@indent_reasons, d_tokens)
         end
 
-        it 'returns true' do
-          subject.multi_line_parens?(2).should be_false
+        it 'returns false' do
+          expect(subject.multi_line_parens?(2)).to eq false
         end
       end
     end
@@ -318,8 +326,8 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
         subject.instance_variable_set(:@indent_reasons, d_tokens)
       end
 
-      it 'returns true' do
-        subject.multi_line_parens?(1).should be_false
+      it 'returns false' do
+        expect(subject.multi_line_parens?(1)).to eq false
       end
     end
   end
@@ -327,7 +335,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
   describe '#last_opening_event' do
     context '@indent_reasons is empty' do
       before { subject.instance_variable_set(:@indent_reasons, []) }
-      specify { subject.last_opening_event(nil).should be_nil }
+      specify { expect(subject.last_opening_event(nil)).to be_nil }
     end
 
     context '@indent_reasons contains the corresponding opening event' do
@@ -339,13 +347,15 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
 
       context 'the corresponding opening event is last' do
         it 'returns the matching opening event' do
-          subject.last_opening_event(:on_rbrace).should == indent_reasons.last
+          expect(subject.last_opening_event(:on_rbrace)).
+            to eq indent_reasons.last
         end
       end
 
       context 'the corresponding opening event is not last' do
         it 'returns the matching opening event' do
-          subject.last_opening_event(:on_rparen).should == indent_reasons.first
+          expect(subject.last_opening_event(:on_rparen)).
+            to eq indent_reasons.first
         end
       end
     end
@@ -365,7 +375,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
         i
       end
 
-      specify { subject.remove_continuation_keywords.should be_nil }
+      specify { expect(subject.remove_continuation_keywords).to be_nil }
     end
 
     context '@indent_reasons does not contain CONTINUATION_KEYWORDS' do
@@ -378,7 +388,7 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
       end
 
       it 'should not call #pop on @indent_reasons' do
-        indent_reasons.should_not_receive(:pop)
+        expect(indent_reasons).to_not receive(:pop)
         subject.remove_continuation_keywords
       end
     end
@@ -391,8 +401,8 @@ describe Tailor::Rulers::IndentationSpacesRuler::IndentationManager do
       it 'should call #pop on @indent_reasons one time' do
         subject.instance_variable_set(:@indent_reasons, indent_reasons)
         subject.remove_continuation_keywords
-        subject.instance_variable_get(:@indent_reasons).should ==
-          [{ token: 'if' }]
+        expect(subject.instance_variable_get(:@indent_reasons)).
+          to eq [{ token: 'if' }]
       end
     end
   end

--- a/spec/unit/tailor/rulers/indentation_spaces_ruler_spec.rb
+++ b/spec/unit/tailor/rulers/indentation_spaces_ruler_spec.rb
@@ -38,19 +38,19 @@ describe Tailor::Rulers::IndentationSpacesRuler do
     it 'sets @embexpr_nesting to [true]' do
       subject.instance_variable_set(:@embexpr_nesting, [])
       subject.embexpr_beg_update(lexed_line, 1, 1)
-      subject.instance_variable_get(:@embexpr_nesting).should == [true]
+      expect(subject.instance_variable_get(:@embexpr_nesting)).to eq [true]
     end
   end
 
   describe '#embexpr_end_update' do
     before do
-      lexed_line.should_receive(:only_embexpr_end?).and_return(false)
+      expect(lexed_line).to receive(:only_embexpr_end?).and_return(false)
     end
 
     it 'pops @embexpr_nesting' do
       subject.instance_variable_set(:@embexpr_nesting, [true])
       subject.embexpr_end_update(lexed_line, 1, 1)
-      subject.instance_variable_get(:@embexpr_nesting).should == []
+      expect(subject.instance_variable_get(:@embexpr_nesting)).to eq []
     end
   end
 
@@ -98,18 +98,18 @@ describe Tailor::Rulers::IndentationSpacesRuler do
     let(:manager) { double 'IndentationManager' }
 
     it 'calls #stop on the indentation_manager object' do
-      manager.should_receive(:update_actual_indentation).with lexed_line
-      manager.should_receive(:stop)
+      expect(manager).to receive(:update_actual_indentation).with lexed_line
+      expect(manager).to receive(:stop)
       subject.instance_variable_set(:@manager, manager)
       subject.tstring_beg_update(lexed_line, 1)
     end
 
     it 'adds the lineno to @tstring_nesting' do
-      manager.stub(:update_actual_indentation)
-      manager.stub(:stop)
+      allow(manager).to receive(:update_actual_indentation)
+      allow(manager).to receive(:stop)
       subject.instance_variable_set(:@manager, manager)
       subject.tstring_beg_update(lexed_line, 1)
-      subject.instance_variable_get(:@tstring_nesting).should == [1]
+      expect(subject.instance_variable_get(:@tstring_nesting)).to eq [1]
     end
   end
 
@@ -118,19 +118,19 @@ describe Tailor::Rulers::IndentationSpacesRuler do
       let(:manager) { double 'IndentationManager' }
 
       it 'calls #start' do
-        manager.should_receive(:start)
+        expect(manager).to receive(:start)
         subject.instance_variable_set(:@manager, manager)
         subject.tstring_end_update(2)
       end
 
       it 'removes the lineno to @tstring_nesting then calls @manager.start' do
-        manager.should_receive(:actual_indentation)
-        manager.should_receive(:start)
+        expect(manager).to receive(:actual_indentation)
+        expect(manager).to receive(:start)
         subject.instance_variable_set(:@manager, manager)
         subject.instance_variable_set(:@tstring_nesting, [1])
-        subject.should_receive(:measure)
+        expect(subject).to receive(:measure)
         subject.tstring_end_update(2)
-        subject.instance_variable_get(:@tstring_nesting).should be_empty
+        expect(subject.instance_variable_get(:@tstring_nesting)).to be_empty
       end
     end
   end

--- a/spec/unit/tailor/rulers/spaces_after_comma_ruler_spec.rb
+++ b/spec/unit/tailor/rulers/spaces_after_comma_ruler_spec.rb
@@ -7,7 +7,7 @@ describe Tailor::Rulers::SpacesAfterCommaRuler do
   describe '#comma_update' do
     it 'adds the column number to @comma_columns' do
       subject.comma_update(',', 2, 1)
-      subject.instance_variable_get(:@comma_columns).should == [1]
+      expect(subject.instance_variable_get(:@comma_columns)).to eq [1]
     end
   end
 
@@ -15,14 +15,14 @@ describe Tailor::Rulers::SpacesAfterCommaRuler do
     context 'no event after comma' do
       let(:lexed_line) do
         l = double 'LexedLine'
-        l.stub(:event_at)
-        l.stub(:index)
+        allow(l).to receive(:event_at)
+        allow(l).to receive(:index)
 
         l
       end
 
       it 'does not detect any problems' do
-        Tailor::Problem.should_not_receive(:new)
+        expect(Tailor::Problem).to_not receive(:new)
         expect { subject.check_spaces_after_comma(lexed_line, 1) }.
           to_not raise_error
       end

--- a/spec/unit/tailor/rulers/spaces_after_lbrace_ruler_spec.rb
+++ b/spec/unit/tailor/rulers/spaces_after_lbrace_ruler_spec.rb
@@ -7,14 +7,14 @@ describe Tailor::Rulers::SpacesAfterLbraceRuler do
   describe '#comment_update' do
     context 'token has a trailing newline' do
       it 'calls #ignored_nl_update' do
-        subject.should_receive(:ignored_nl_update)
+        expect(subject).to receive(:ignored_nl_update)
         subject.comment_update("\n", '', '', 1, 1)
       end
     end
 
     context 'token does not have a trailing newline' do
       it 'does not call #ignored_nl_update' do
-        subject.should_not_receive(:ignored_nl_update)
+        expect(subject).to_not receive(:ignored_nl_update)
         subject.comment_update('# comment', '', '', 1, 1)
       end
     end
@@ -22,7 +22,7 @@ describe Tailor::Rulers::SpacesAfterLbraceRuler do
 
   describe '#ignored_nl_update' do
     it 'calls #check_spaces_after_lbrace' do
-      subject.should_receive(:check_spaces_after_lbrace)
+      expect(subject).to receive(:check_spaces_after_lbrace)
       subject.ignored_nl_update('', 1, 1)
     end
   end
@@ -30,13 +30,13 @@ describe Tailor::Rulers::SpacesAfterLbraceRuler do
   describe '#lbrace_update' do
     it 'adds column to @lbrace_columns' do
       subject.lbrace_update('', 1, 1)
-      subject.instance_variable_get(:@lbrace_columns).should == [1]
+      expect(subject.instance_variable_get(:@lbrace_columns)).to eq [1]
     end
   end
 
   describe '#nl_update' do
     it 'calls #ignored_nl_update' do
-      subject.should_receive(:ignored_nl_update)
+      expect(subject).to receive(:ignored_nl_update)
       subject.nl_update('', 1, 1)
     end
   end
@@ -51,8 +51,8 @@ describe Tailor::Rulers::SpacesAfterLbraceRuler do
       end
 
       it 'breaks from the loop and returns nil' do
-        lexed_line.should_not_receive(:at)
-        subject.count_spaces(lexed_line, 1).should be_nil
+        expect(lexed_line).to_not receive(:at)
+        expect(subject.count_spaces(lexed_line, 1)).to be_nil
       end
     end
 
@@ -66,7 +66,7 @@ describe Tailor::Rulers::SpacesAfterLbraceRuler do
       end
 
       it 'returns 0' do
-        subject.count_spaces(lexed_line, 1).should be_zero
+        expect(subject.count_spaces(lexed_line, 1)).to be_zero
       end
     end
 
@@ -77,14 +77,14 @@ describe Tailor::Rulers::SpacesAfterLbraceRuler do
 
       let(:lexed_line) do
         l = double 'LexedLine'
-        l.stub(:event_index).and_return 1
-        l.should_receive(:at).with(2).and_return next_event
+        allow(l).to receive(:event_index).and_return 1
+        expect(l).to receive(:at).with(2).and_return next_event
 
         l
       end
 
       it 'returns 0' do
-        subject.count_spaces(lexed_line, 1).should be_zero
+        expect(subject.count_spaces(lexed_line, 1)).to be_zero
       end
     end
 
@@ -95,8 +95,8 @@ describe Tailor::Rulers::SpacesAfterLbraceRuler do
 
       let(:lexed_line) do
         l = double 'LexedLine'
-        l.stub(:event_index).and_return 1
-        l.should_receive(:at).with(2).and_return next_event
+        allow(l).to receive(:event_index).and_return 1
+        expect(l).to receive(:at).with(2).and_return next_event
 
         l
       end
@@ -113,14 +113,14 @@ describe Tailor::Rulers::SpacesAfterLbraceRuler do
 
       let(:lexed_line) do
         l = double 'LexedLine'
-        l.stub(:event_index).and_return 1
-        l.stub(:at).and_return next_event
+        allow(l).to receive(:event_index).and_return 1
+        allow(l).to receive(:at).and_return next_event
 
         l
       end
 
       it 'returns 0' do
-        subject.count_spaces(lexed_line, 1).should be_zero
+        expect(subject.count_spaces(lexed_line, 1)).to be_zero
       end
     end
 
@@ -131,14 +131,14 @@ describe Tailor::Rulers::SpacesAfterLbraceRuler do
 
       let(:lexed_line) do
         l = double 'LexedLine'
-        l.stub(:event_index).and_return 1
-        l.stub(:at).and_return next_event
+        allow(l).to receive(:event_index).and_return 1
+        allow(l).to receive(:at).and_return next_event
 
         l
       end
 
       it 'returns 2' do
-        subject.count_spaces(lexed_line, 1).should == 2
+        expect(subject.count_spaces(lexed_line, 1)).to eq 2
       end
     end
   end

--- a/spec/unit/tailor/rulers/spaces_before_lbrace_ruler_spec.rb
+++ b/spec/unit/tailor/rulers/spaces_before_lbrace_ruler_spec.rb
@@ -15,12 +15,12 @@ describe Tailor::Rulers::SpacesBeforeLbraceRuler do
         l
       end
 
-      specify { subject.count_spaces(lexed_line, 1).should be_zero }
+      specify { expect(subject.count_spaces(lexed_line, 1)).to be_zero }
 
       it 'sets @do_measurement to false' do
         expect { subject.count_spaces(lexed_line, 1) }.
-          to change{subject.instance_variable_get(:@do_measurement)}.from(true).
-          to(false)
+          to change { subject.instance_variable_get(:@do_measurement) }.
+          from(true).to(false)
       end
     end
 
@@ -33,7 +33,7 @@ describe Tailor::Rulers::SpacesBeforeLbraceRuler do
         l
       end
 
-      specify { subject.count_spaces(lexed_line, 1).should be_zero }
+      specify { expect(subject.count_spaces(lexed_line, 1)).to be_zero }
     end
 
     context '1 space before lbrace' do
@@ -45,7 +45,7 @@ describe Tailor::Rulers::SpacesBeforeLbraceRuler do
         l
       end
 
-      specify { subject.count_spaces(lexed_line, 1).should == 1 }
+      specify { expect(subject.count_spaces(lexed_line, 1)).to eq 1 }
     end
 
     context '> 1 space before lbrace' do
@@ -57,7 +57,7 @@ describe Tailor::Rulers::SpacesBeforeLbraceRuler do
         l
       end
 
-      specify { subject.count_spaces(lexed_line, 3).should == 2 }
+      specify { expect(subject.count_spaces(lexed_line, 3)).to eq 2 }
     end
   end
 end

--- a/spec/unit/tailor/rulers/spaces_before_rbrace_ruler_spec.rb
+++ b/spec/unit/tailor/rulers/spaces_before_rbrace_ruler_spec.rb
@@ -19,8 +19,8 @@ describe Tailor::Rulers::SpacesBeforeRbraceRuler do
 
       it 'sets @do_measurement to false' do
         expect { subject.count_spaces(lexed_line, 1) }.
-          to change{subject.instance_variable_get(:@do_measurement)}.from(true).
-          to(false)
+          to change { subject.instance_variable_get(:@do_measurement) }.
+          from(true).to(false)
       end
     end
 

--- a/spec/unit/tailor/rulers/spaces_before_rbrace_ruler_spec.rb
+++ b/spec/unit/tailor/rulers/spaces_before_rbrace_ruler_spec.rb
@@ -15,7 +15,7 @@ describe Tailor::Rulers::SpacesBeforeRbraceRuler do
         l
       end
 
-      specify { subject.count_spaces(lexed_line, 1).should be_zero }
+      specify { expect(subject.count_spaces(lexed_line, 1)).to be_zero }
 
       it 'sets @do_measurement to false' do
         expect { subject.count_spaces(lexed_line, 1) }.
@@ -33,7 +33,7 @@ describe Tailor::Rulers::SpacesBeforeRbraceRuler do
         l
       end
 
-      specify { subject.count_spaces(lexed_line, 1).should be_zero }
+      specify { expect(subject.count_spaces(lexed_line, 1)).to be_zero }
     end
 
     context '1 space before rbrace' do
@@ -45,7 +45,7 @@ describe Tailor::Rulers::SpacesBeforeRbraceRuler do
         l
       end
 
-      specify { subject.count_spaces(lexed_line, 1).should == 1 }
+      specify { expect(subject.count_spaces(lexed_line, 1)).to eq 1 }
     end
 
     context '> 1 space before rbrace' do
@@ -57,7 +57,7 @@ describe Tailor::Rulers::SpacesBeforeRbraceRuler do
         l
       end
 
-      specify { subject.count_spaces(lexed_line, 1).should == 2 }
+      specify { expect(subject.count_spaces(lexed_line, 1)).to eq 2 }
     end
   end
 end

--- a/spec/unit/tailor/rulers_spec.rb
+++ b/spec/unit/tailor/rulers_spec.rb
@@ -4,6 +4,6 @@ require 'tailor/rulers'
 describe Tailor::Rulers do
   it 'requires all of its children' do
     # if it does one, it'll have done them all.
-    subject.const_get('AllowCamelCaseMethodsRuler').should be_true
+    expect(subject.const_get('AllowCamelCaseMethodsRuler')).to be_truthy
   end
 end

--- a/spec/unit/tailor/version_spec.rb
+++ b/spec/unit/tailor/version_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'tailor/version'
 
-
 describe Tailor::VERSION do
-  it { should == '1.4.0' }
+  it { is_expected.to eq '1.4.0' }
 end

--- a/spec/unit/tailor_spec.rb
+++ b/spec/unit/tailor_spec.rb
@@ -6,12 +6,12 @@ describe Tailor do
 
   describe '.config' do
     it 'creates a new Configuration object' do
-      Tailor::Configuration.should_receive(:new)
+      expect(Tailor::Configuration).to receive(:new)
       Tailor.config
     end
 
     it 'returns a Configuration object' do
-      Tailor.config.should be_a Tailor::Configuration
+      expect(Tailor.config).to be_a Tailor::Configuration
     end
   end
 end

--- a/tailor.gemspec
+++ b/tailor.gemspec
@@ -26,7 +26,7 @@ project, whatever style that may be.
   s.test_files = `git ls-files -- {spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  s.add_runtime_dependency 'log_switch', '= 0.3.0' # log_switch 1.0.0 isn't compatable
+  s.add_runtime_dependency 'log_switch', '~> 0.3.0'
   s.add_runtime_dependency 'nokogiri', '>= 1.6.0'
   s.add_runtime_dependency 'term-ansicolor', '>= 1.0.5'
   s.add_runtime_dependency 'text-table', '>= 1.2.2'
@@ -36,8 +36,8 @@ project, whatever style that may be.
   s.add_development_dependency 'cucumber', '>= 1.0.2'
   s.add_development_dependency 'fakefs', '>= 0.4.2'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '>= 2.5.0'
+  s.add_development_dependency 'rspec', '~> 3.1'
+  s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'simplecov', '>= 0.4.0'
   s.add_development_dependency 'yard', '>= 0.7.0'
 end
-


### PR DESCRIPTION
Initial impetus for the changes were to merge in the log_switch fixes.  Lots of tests were broken from previous changes--fixed those.  Also updated specs to follow RSpec 3 style.  Also cleaned up some style stuff.
